### PR TITLE
Implement TimeTables view

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,8 @@
 //= require jquery2
 //= require jquery_ujs
 //
+//= require jquery.loadmask
+//
 //= require moment
 //= require moment-range
 //

--- a/app/assets/javascripts/templates/dashboard.jst.hamljs
+++ b/app/assets/javascripts/templates/dashboard.jst.hamljs
@@ -14,4 +14,4 @@
 
 .panel.panel-primary
   .panel-heading Vacations Time Table
-  .panel-body#time-table-content
+  .panel-body.time-table-content

--- a/app/assets/javascripts/templates/time_table_by_day.jst.hamljs
+++ b/app/assets/javascripts/templates/time_table_by_day.jst.hamljs
@@ -1,0 +1,7 @@
+.col-md-2
+  %table.members
+    %tbody
+
+.scroll-x
+  %table.time-table-by-day
+    %tbody

--- a/app/assets/javascripts/templates/time_tables.jst.hamljs
+++ b/app/assets/javascripts/templates/time_tables.jst.hamljs
@@ -1,8 +1,22 @@
-//.input-group
-  %label.input-group-addon{for:'view-type'} View by:
-  %select.form-control{name:'view-type'}
-    %option{value:'day'} day
-    %option{value:'week'} week
-    %option{value:'month'} month
+%form.form-inline.clearfix
+  .pull-right
+    .input-group
+      %label.input-group-addon{for:'from'} From:
+      %input.form-control{name:'from', type:'date', value:from}
 
-.time-table
+    .input-group
+      %label.input-group-addon{for:'to'} To:
+      %input.form-control{name:'to', type:'date', value:to}
+
+    .input-group
+      %label.input-group-addon{for:'view-type'} View by:
+      %select.form-control{name:'view-type'}
+        :if viewType === 'day'
+          %option{value:'day', selected:true} day
+          %option{value:'week'} week
+        :if viewType === 'week'
+          %option{value:'day'} day
+          %option{value:'week', selected:true} week
+
+
+.time-tables

--- a/app/assets/javascripts/views/dashboard.js
+++ b/app/assets/javascripts/views/dashboard.js
@@ -26,15 +26,15 @@ App.Views.Dashboard = Backbone.View.extend({
 
     this.$el.html(this.template(this.attributes));
     this.$('select[name=teams]').trigger('change');
-    // this.updateUsersRequestsVisibility();
-    // this.renderPersonalRequests();
+    this.updateUsersRequestsVisibility();
+    this.renderPersonalRequests();
     return this;
   },
 
   onTeams: function( e ) {
     this.teamID = parseInt(e.target.value);
     this.attributes.role = App.currentUserRoles.roleFromTeamID(this.teamID);
-    // this.updateUsersRequestsVisibility();
+    this.updateUsersRequestsVisibility();
     this.renderTimeTable();
   },
 
@@ -86,11 +86,14 @@ App.Views.Dashboard = Backbone.View.extend({
   },
 
   renderTimeTable: function() {
-    var options = {team_id: this.teamID};
+    var options = {team_ids: [1,2,3]};
+        options.from  = moment();
+        options.to    = moment().add(2,'months');
+
     if (_.isUndefined(this.timeTables)) {
       this.timeTables = new App.Views.TimeTables(options);
     } else {
-      this.timeTables.update(options.team_id);
+      this.timeTables.update(options.teams);
     }
   },
 

--- a/app/assets/javascripts/views/time_tables.js
+++ b/app/assets/javascripts/views/time_tables.js
@@ -1,30 +1,39 @@
 App.Views.TimeTables = Backbone.View.extend({
-  el: '#time-table-content',
+  el: '.time-table-content',
   template: JST['templates/time_tables'],
 
-  initialize: function( options ) {
-    this.members = new App.Collections.TeamMembers(options.team_id);
-    this.listenTo(this.members,  'sync',  this.render);
-    this.members.fetch();
+  events: {
+    'change input[name=from]':  'onFrom',
+    'change input[name=to]':    'onTo',
+
+    'change select[name=view-type]':    'onViewType'
+  },
+
+  initialize: function(options) {
     this.attributes = {};
-    this.attributes.team_id = options.team_id;
     this.timeTableDateRange = {};
 
+    this.teamIDs = options.team_ids;
+    this.timeTableViews = [];
+
+    this.setDefaultViewType();
+    this.setDefaultDateRange();
+
+    this.render();
   },
 
   render: function() {
-    this.renderTemplate();
-    this.renderTeamMembersList();
-    this.renderTimeTableByWeek();
+    this.renderTemplate(this.attributes);
+    this.renderTimeTables();
+
     return this;
   },
 
-
-  update: function( teamID ) {
+  update: function(teamIDs) {
     delete this.members;
-    this.updateTeamMembersList(teamID);
-    this.attributes.team_id = teamID;
-    this.renderTemplate();
+    this.teamIDs = teamIDs;
+    // this.renderTemplate();
+    this.renderTimeTables();
     return this;
   },
 
@@ -32,219 +41,73 @@ App.Views.TimeTables = Backbone.View.extend({
     this.$el.html(this.template(this.attributes));
   },
 
-  // TODO: move to the model
-  composeFullName: function(model) {
-    var result = '';
-    var value = model.attributes.first_name;
-    if (_.isString(value)) {
-      result = value.trim();
-    }
-    value = model.attributes.last_name;
-    if (_.isString(value)) {
-      result.concat(' ' + value.trim());
-    }
-    return result;
+  // *************************************************************************
+  renderTimeTables: function() {
+    var $timeTableContainer = null;
+    var selector = '';
+    var timeTable = this.getTimeTableType();
+
+    this.$('.time-tables').empty();
+    this.destroyTimeTables();
+
+    this.teamIDs.forEach(function(id) {
+      selector = 'team'+id;
+      $timeTableContainer = $('<div>').appendTo('.time-tables')
+        .attr('id', selector);
+      this.timeTableViews.push( new timeTable({
+                                  team_id: id,
+                                  el:   '#'+selector,
+                                  from: this.timeTableDateRange.begin,
+                                  to:   this.timeTableDateRange.end
+                                }));
+    }, this);
+  },
+
+  updateTimeTables: function() {
+    this.timeTableViews.forEach(function(view) {
+      view.update(this.timeTableDateRange);
+    }, this);
+  },
+
+  destroyTimeTables: function() {
+    this.timeTableViews.forEach(function(view) {
+      view.remove();
+    });
+  },
+
+  getTimeTableType: function() {
+    return this.viewType === 'day' ? App.Views.TimeTableByDay : App.Views.TimeTableByWeek;
   },
 
   // *************************************************************************
-  renderTeamMembersList: function() {
-    var $list = $('.members tbody');
-    $list.append('<tr><td>&nbsp;</td></tr>');
-    $list.append('<tr><td>&nbsp;</td></tr>');
-    this.members.each(function(model) {
-      $list.append('<tr><td class="member">'+ this.composeFullName(model) +'</td></tr>');
-    }, this);
+  onFrom: function(e) {
+    this.timeTableDateRange.begin = moment(e.target.value);
+    this.updateTimeTables();
   },
 
-  updateTimeTableDateRange: function() {
-    // code here
-    var now = new Date();
-    this.timeTableDateRange.begin = new Date(now.getFullYear(),
-                                             now.getMonth(),
-                                             now.getDate());
-    this.timeTableDateRange.end   = new Date(now.getFullYear(),
-                                             now.getMonth() + 6,
-                                             now.getDate());
+  onTo: function(e) {
+    this.timeTableDateRange.end   = moment(e.target.value);
+    this.updateTimeTables();
   },
 
-  calculateTableWidth: function(cellWidth) {
-    return this.getNumberOfDays() * cellWidth;
-  },
+  onViewType: function(e) {
+    this.viewType = e.target.value;
+    this.attributes.viewType = this.viewType;
 
-  getNumberOfDays: function() {
-    var beginDateMS = App.Helpers.dateToMS(this.timeTableDateRange.begin);
-    var endDateMS   = App.Helpers.dateToMS(this.timeTableDateRange.end);
-    var durationMS  = endDateMS - beginDateMS;
-
-    return App.Helpers.MsToNumberOfDays(durationMS);
-  },
-
-  colorizeVacation: function(vacation) {
-    var colors = {
-      requested: 'gold',
-      accepted: 'skyblue',
-      inprogress: 'lime'
-    };
-    return colors[vacation.status];
-  },
-
-  styleVacation: function(vacation) {
-    var colors = {
-      planned: 'dotted',
-      unpaid: 'dashed',
-      sickness: 'double'
-    };
-    return colors[vacation.kind];
-  },
-
-  markVacation: function(vacation) {
-    var duration = vacation.duration;
-    var startDate = new Date(vacation.start);
-    var userID = vacation.user_id;
-    var day = 0;
-
-    for (var i = 0; i < duration; i++) {
-      date = App.Helpers.dateFromOffset(startDate, i);
-      if (App.Helpers.isWeekend(date)) {
-        duration++;
-        continue;
-      }
-      selector = '#'+userID+'-'+App.Helpers.dateToISO_8601(date);
-      $(selector).css('background-color', this.colorizeVacation(vacation));
-      $(selector).css('border-style', this.styleVacation(vacation));
-    }
-  },
-
-  markVacations: function( collection ) {
-    _.each(collection, function(vacations) {
-      if (!_.isEmpty(vacations)) {
-        _.each(vacations, function(vacation) {
-          this.markVacation(vacation);
-        }, this);
-      }
-    }, this);
-  },
-
-  drawMonths: function() {
-    var cols = this.getNumberOfDays();
-    var cellSize = 20;
-    var tableWidth = this.calculateTableWidth(cellSize);
-    var start = this.timeTableDateRange.begin;
-    var year = start.getFullYear();
-    var month = App.Helpers.getMonthNameFromDate(start);
-    var cellCounter = 0;
-    var $td = null;
-
-    $('#time-table').css('width', tableWidth);
-
-    var $tr = $('<tr>').appendTo(this.$table);
-    $tr.addClass('months');
-
-    for (var col = 0; col < cols; col++) {
-      date  = App.Helpers.dateFromOffset(start, col);
-      if (App.Helpers.getMonthNameFromDate(date) !== month) {
-        $td = $('<td>').appendTo($tr);
-        $td.attr('colspan',cellCounter);
-        $td.text(month+' ('+year+')');
-        month = App.Helpers.getMonthNameFromDate(date);
-        year = date.getFullYear();
-        cellCounter = 0;
-      }
-      cellCounter++;
-    }
-
-    if (cellCounter > 0) {
-        $td = $('<td>').appendTo($tr);
-        $td.attr('colspan',cellCounter);
-        $td.text(month+' ('+year+')');
-    }
-  },
-
-  drawDays: function() {
-    var cols = this.getNumberOfDays();
-    var cellSize = 25;
-    var tableWidth = this.calculateTableWidth(cellSize);
-    var start = this.timeTableDateRange.begin;
-    var day = 0;
-    var $td = null;
-
-    var $tr = $('<tr>').appendTo(this.$table);
-    $tr.addClass('days');
-
-    for (var col = 0; col < cols; col++) {
-      date  = App.Helpers.dateFromOffset(start, col);
-      day   = date.getDate();
-      $td = $('<td>').appendTo($tr);
-      $td.text(day);
-
-      if (App.Helpers.isWeekend(date)) {
-        $td.css('background-color: grey');
-      }
-    }
-  },
-
-  drawEmptyTable: function() {
-    var cols = this.getNumberOfDays();
-    var cellSize = 20;
-    var tableWidth = this.calculateTableWidth(cellSize);
-    var start = this.timeTableDateRange.begin;
-    var userID = 0;
-    var date = 0;
-    var cellID = '';
-    var style = '';
-    var $tr = null;
-    var $td = null;
-
-    this.members.each( function(user) {
-      userID = user.attributes.id;
-      $tr = $('<tr>').appendTo(this.$table);
-      for (var col = 0; col < cols; col++) {
-        date = App.Helpers.dateFromOffset(start, col);
-        cellID = userID+'-'+App.Helpers.dateToISO_8601(date);
-        $td = $('<td>').appendTo($tr);
-        $td.attr('id',cellID);
-        if (App.Helpers.isWeekend(date)) {
-          $td.css('background-color','grey');
-        }
-      }
-    }, this);
-  },
-
-  drawTableCaption: function() {
-    this.drawMonths();
-    this.drawDays();
-  },
-
-  drawTable: function( collection ) {
-    this.updateTimeTableDateRange();
-    this.drawTableCaption();
-    this.drawEmptyTable();
-    this.markVacations(collection);
-  },
-
-  renderTimeTableByDay: function() {
-    var that = this;
-    this.$table = $('#time-table tbody');
-    var vacations = new App.Collections.TeamVacations({team_id: this.attributes.team_id});
-    vacations.fetch()
-      .then(function(data) {
-        that.drawTable(data);
-      });
-  },
-
-  renderTimeTableByWeek: function() {
-    var that = this;
-    this.$table = $('#time-table tbody');
-    this.timeTableByWeek = new App.Views.TimeTableByWeek({team_id: this.attributes.team_id});
+    this.update(this.teamIDs);
   },
   // *************************************************************************
 
-  updateTeamMembersList: function( teamID ) {
-    if (!_.isUndefined(this.members)) {
-      delete this.members;
-    }
-    this.members = new App.Collections.TeamMembers(teamID);
-    this.members.fetch();
+  setDefaultDateRange: function() {
+    var now = moment();
+    this.timeTableDateRange.begin = moment(now.format('YYYY-MM-DD'));
+    this.timeTableDateRange.end   = moment().add(3, 'months');
+    this.attributes.from  = this.timeTableDateRange.begin.format('YYYY-MM-DD');
+    this.attributes.to    = this.timeTableDateRange.end.format('YYYY-MM-DD');
   },
 
+  setDefaultViewType: function() {
+    this.viewType = 'day';
+    this.attributes.viewType = this.viewType;
+  }
 });

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,7 @@
 $planned-vacation: #0a0;
 $unpaid-vacation: #4b0082;
 $sickness-vacation: #f00;
+$weekend: #ddd;
 $silver: #c0c0c0;
 
 .footer {
@@ -76,6 +77,7 @@ $silver: #c0c0c0;
   }
 }
 
+.time-table-by-day,
 .time-table-by-week {
   border-collapse: collapse;
 
@@ -134,4 +136,28 @@ $silver: #c0c0c0;
 
 .sickness {
   background-color: $sickness-vacation;
+}
+
+.weekend {
+  background-color: $weekend;
+}
+
+.time-table-by-day {
+  .inprogress {
+    background-image: repeating-linear-gradient(
+        transparent,
+        $gray-lighter 25%,
+        transparent 50%
+      );
+  }
+}
+
+.time-table-content {
+  form {
+    margin-bottom: 10px;
+  }
+
+  .input-group {
+    padding-left: 5px;
+  }
 }

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -49,9 +49,7 @@ class TeamsController < ApplicationController
   def vacations
     if @team
       vacations = VacationRequest
-                  .joins(user: { team_roles: :team })
-                  .where(team_roles: { team_id: @team })
-                  .select(:id, :user_id, :start, :duration, :kind, :status)
+                  .team_vacations(@team)
                   .requested_accepted_inprogress
       render json: vacations
     else

--- a/app/models/vacation_request.rb
+++ b/app/models/vacation_request.rb
@@ -8,6 +8,12 @@ class VacationRequest < ActiveRecord::Base
                    VacationRequest.statuses[:inprogress]])
   }
 
+  scope :team_vacations, lambda { |team|
+    joins(user: :team_roles)
+      .where(team_roles: { team_id: team.id })
+      .select(:id, :user_id, :start, :duration, :kind, :status)
+  }
+
   enum status: [
     :requested,
     :accepted,

--- a/vendor/assets/javascripts/jquery.loadmask.js
+++ b/vendor/assets/javascripts/jquery.loadmask.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2009 Sergiy Kovalchuk (serg472@gmail.com)
+ * 
+ * Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+ * and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
+ *  
+ * Following code is based on Element.mask() implementation from ExtJS framework (http://extjs.com/)
+ *
+ */
+(function(a){a.fn.mask=function(c,b){a(this).each(function(){if(b!==undefined&&b>0){var d=a(this);d.data("_mask_timeout",setTimeout(function(){a.maskElement(d,c)},b))}else{a.maskElement(a(this),c)}})};a.fn.unmask=function(){a(this).each(function(){a.unmaskElement(a(this))})};a.fn.isMasked=function(){return this.hasClass("masked")};a.maskElement=function(d,c){if(d.data("_mask_timeout")!==undefined){clearTimeout(d.data("_mask_timeout"));d.removeData("_mask_timeout")}if(d.isMasked()){a.unmaskElement(d)}if(d.css("position")=="static"){d.addClass("masked-relative")}d.addClass("masked");var e=a('<div class="loadmask"></div>');if(navigator.userAgent.toLowerCase().indexOf("msie")>-1){e.height(d.height()+parseInt(d.css("padding-top"))+parseInt(d.css("padding-bottom")));e.width(d.width()+parseInt(d.css("padding-left"))+parseInt(d.css("padding-right")))}if(navigator.userAgent.toLowerCase().indexOf("msie 6")>-1){d.find("select").addClass("masked-hidden")}d.append(e);if(c!==undefined){var b=a('<div class="loadmask-msg" style="display:none;"></div>');b.append("<div>"+c+"</div>");d.append(b);b.css("top",Math.round(d.height()/2-(b.height()-parseInt(b.css("padding-top"))-parseInt(b.css("padding-bottom")))/2)+"px");b.css("left",Math.round(d.width()/2-(b.width()-parseInt(b.css("padding-left"))-parseInt(b.css("padding-right")))/2)+"px");b.show()}};a.unmaskElement=function(b){if(b.data("_mask_timeout")!==undefined){clearTimeout(b.data("_mask_timeout"));b.removeData("_mask_timeout")}b.find(".loadmask-msg,.loadmask").remove();b.removeClass("masked");b.removeClass("masked-relative");b.find("select").removeClass("masked-hidden")}})(jQuery);


### PR DESCRIPTION
`TimeTables` view is able to render provided list of teams.
All teams are rendered according to selected date range and view type.
Date range can be specified with HTML input controls.
View type  can be specified with HTML select control.
All the time tables are updated on date range and view type updates.

Improvements:
  Extract joins in `teams#vacations` into `VacationRequest` model scope.
  Remove joining of `teams` in `teams#vacations`.

Integrations:
  jQuery load mask plugin

UPD @alazarchuk , @epmlys 
