### PR TITLE
Add RSpec features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'mysql2'
 gem 'jbuilder', '~> 2.0'
 gem 'devise'
 gem 'devise_invitable'
+gem 'pundit'
 
 group :development, :test do
   gem 'spring'
@@ -20,6 +21,9 @@ group :development do
 end
 
 group :test do
+  gem 'database_cleaner'
+  gem 'capybara'
+  gem 'poltergeist'
   gem 'shoulda-matchers', require: false
   gem 'ffaker',           require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,13 @@ GEM
     brice (0.4.0)
       nuggets
     builder (3.2.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    cliver (0.3.2)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -55,6 +62,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    database_cleaner (1.4.1)
     devise (3.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -106,6 +114,13 @@ GEM
     nuggets (1.2.1)
     orm_adapter (0.5.0)
     phantomjs (1.9.8.0)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
+    pundit (1.0.1)
+      activesupport (>= 3.0.0)
     rack (1.6.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -182,6 +197,11 @@ GEM
       json (>= 1.8.0)
     warden (1.2.3)
       rack (>= 1.0)
+    websocket-driver (0.6.2)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -190,7 +210,9 @@ DEPENDENCIES
   awesome_print
   bootstrap-sass (~> 3.3)
   brice
+  capybara
   coffee-rails (~> 4.1.0)
+  database_cleaner
   devise
   devise_invitable
   factory_girl_rails (~> 4.5)
@@ -200,6 +222,8 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   mysql2
+  poltergeist
+  pundit
   rails (= 4.2.1)
   rspec-rails (~> 3.0)
   ruby-haml-js

--- a/app/assets/javascripts/collections/current_user_roles.js
+++ b/app/assets/javascripts/collections/current_user_roles.js
@@ -1,7 +1,5 @@
 App.Collections.CurrentUserRoles = Backbone.Collection.extend({
-  url: 'users',
-
-  roleFromTeamID: function( teamID ) {
+  roleFromTeamID: function(teamID) {
     var result = null;
 
       result = this.find(function(model) {
@@ -17,5 +15,31 @@ App.Collections.CurrentUserRoles = Backbone.Collection.extend({
     });
 
     return result;
+  },
+
+  highestPrivilege: function() {
+    var result = 'guest';
+    result = this.max(function(model) {
+      return this.getRoleAsNumber(model.get('role'));
+    }, this).get('role');
+
+    return result;
+  },
+
+  getRoleAsNumber: function(role) {
+    var number = 0;
+
+    switch (role) {
+      case 'member':
+        number = 1;
+        break;
+      case 'manager':
+        number = 2;
+        break;
+      default:
+        number = 0;
+    }
+
+    return number;
   }
 });

--- a/app/assets/javascripts/models/current_user.js
+++ b/app/assets/javascripts/models/current_user.js
@@ -1,13 +1,2 @@
 App.Models.CurrentUser = Backbone.Model.extend({
-  urlRoot: 'users',
-  parse: function( data ) {
-    var result = {};
-    result = App.Helpers.extractObject(data,'current_user');
-    // We have enough data to populate roles as well
-    App.currentUserRoles = new App.Collections.CurrentUserRoles(
-      App.Helpers.extractObject(data,'current_user_roles')
-    );
-
-    return result;
-  }
 });

--- a/app/assets/javascripts/routers/router.js
+++ b/app/assets/javascripts/routers/router.js
@@ -11,11 +11,6 @@ App.Router = Backbone.Router.extend({
     'calendar':               'calendar',
   },
 
-  initialize: function( options ) {
-    App.currentUser = new App.Models.CurrentUser();
-    App.currentUser.fetch();
-  },
-
   dashboard: function() {
     $('.content').html("Dashboard =)");
     App.dashboard = new App.Views.Dashboard();

--- a/app/assets/javascripts/templates/team.jst.hamljs
+++ b/app/assets/javascripts/templates/team.jst.hamljs
@@ -1,5 +1,6 @@
 .view
   = name
-  %input.pull-right.btn.btn-xs.btn-danger.remove{type:'button', value:'Delete'}
+  :if role === 'manager'
+    %input.pull-right.btn.btn-xs.btn-danger.remove{type:'button', value:'Delete'}
 
 %input.edit{type:'text', value:"#{name}"}

--- a/app/assets/javascripts/templates/teams.jst.hamljs
+++ b/app/assets/javascripts/templates/teams.jst.hamljs
@@ -2,9 +2,10 @@
   .panel-heading Teams
   .panel-body
     #teams
-      %form.team-create{role:'form'}
-        .input-group
-          %input.form-control{name:'team-name', type:'text', placeholder:'Team name...', autofocus:true}
-          %span.input-group-btn
-            %button.btn.btn-default{name:'add'} Add
+      :if highestPrivilege === 'manager'
+        %form.team-create{role:'form'}
+          .input-group
+            %input.form-control{name:'team-name', type:'text', placeholder:'Team name...', autofocus:true}
+            %span.input-group-btn
+              %button.btn.btn-default{name:'add'} Add
       %ul.teams-list.list-group

--- a/app/assets/javascripts/views/team.js
+++ b/app/assets/javascripts/views/team.js
@@ -4,15 +4,41 @@ App.Views.Team = Backbone.View.extend({
   template: JST['templates/team'],
 
   events: {
-    'click .remove':  'onRemove',
-    'dblclick .view': 'edit',
-    'keypress .edit': 'updateOnEnter',
+  },
+
+  initialize: function(options) {
+    this.model = options.model;
+    this.attributes = {
+      role: App.currentUserRoles.highestPrivilege()
+    };
+    this.addAuthorizedEvents();
   },
 
   render: function() {
-    var html = this.template(this.model.attributes);
+    var attributes = this.model.attributes;
+
+    attributes.role = this.attributes.role;
     this.listenTo(this.model, 'change:name', this.updateName);
-    this.$el.html(html);
+    this.$el.html(this.template(attributes));
+
+    return this;
+  },
+
+  addAuthorizedEvents: function() {
+    var role = this.attributes.role;
+    switch (role) {
+      case 'manager':
+        this.addEventsForManager();
+        break;
+    }
+
+    return this;
+  },
+
+  addEventsForManager: function() {
+    this.events['click .remove']  = 'onRemove';
+    this.events['dblclick .view'] = 'edit';
+    this.events['keypress .edit'] = 'updateOnEnter';
     return this;
   },
 

--- a/app/assets/javascripts/views/teams.js
+++ b/app/assets/javascripts/views/teams.js
@@ -7,7 +7,10 @@ App.Views.Teams = Backbone.View.extend({
   },
 
   initialize: function(options) {
-    this.$el.html(this.template());
+    this.attributes = {
+      highestPrivilege: App.currentUserRoles.highestPrivilege()
+    };
+    this.$el.html(this.template(this.attributes));
     this.collection = options.collection;
     this.listenTo(this.collection, 'add',  this.addTeam);
     this.listenTo(this.collection, 'sync', this.render);
@@ -37,11 +40,11 @@ App.Views.Teams = Backbone.View.extend({
         errors  = model.preValidate('name', value);
 
     if ( errors ) {
-      console.log(errors);
+      // TODO: inform user about errors
     } else {
+      // TODO: inform user about success
       this.collection.create({'name': value});
 
-      console.log('Valid team name is added to the collection.');
       input.val('');
     }
   },

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,11 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
+  include Pundit
+
+  rescue_from Pundit::NotAuthorizedError do
+    head status: :forbidden
+  end
+
   protect_from_forgery with: :exception
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -12,6 +12,7 @@ class TeamsController < ApplicationController
 
   def create
     team = Team.new team_params
+    authorize team
     if team.save
       render json: team
     else
@@ -20,6 +21,7 @@ class TeamsController < ApplicationController
   end
 
   def update
+    authorize @team
     if @team.update(team_params)
       head status: :no_content
     else
@@ -28,6 +30,7 @@ class TeamsController < ApplicationController
   end
 
   def destroy
+    authorize @team
     @team.destroy
     head status: :no_content
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,21 +1,12 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+
   def index
-    fetch_current_user_details
-    render json: {
-      current_user: current_user,
-      current_user_roles: @current_user_roles,
-      users: User.all
-    }
+    render json: User.all
   end
 
   def requested_vacations
     requests = VacationRequest.where(user_id: params[:id]).requested
     render json: requests
-  end
-
-private
-
-  def fetch_current_user_details
-    @current_user_roles = current_user.team_roles unless current_user.nil?
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,5 @@
 class Team < ActiveRecord::Base
-  has_many  :team_roles
+  has_many  :team_roles, dependent: :destroy
   has_many  :users, through: :team_roles
 
   validates :name,

--- a/app/models/team_role.rb
+++ b/app/models/team_role.rb
@@ -2,6 +2,18 @@ class TeamRole < ActiveRecord::Base
   belongs_to  :user
   belongs_to  :team
 
+  scope :managers, lambda {
+    where(role: TeamRole.roles[:manager])
+  }
+
+  scope :members, lambda {
+    where(role: TeamRole.roles[:member])
+  }
+
+  scope :guests, lambda {
+    where(role: TeamRole.roles[:guest])
+  }
+
   validates :role,    presence: true
   validates :team_id, presence: true
   validates :user_id,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,12 @@ class User < ActiveRecord::Base
   has_many  :vacation_requests, dependent: :destroy
   has_many  :available_vacations, dependent: :destroy
   has_many  :approval_requests, foreign_key: :manager_id, dependent: :destroy
+
+  def manager_of?(team)
+    team_roles.managers.where(team: team).exists?
+  end
+
+  def manager?
+    team_roles.managers.exists?
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,24 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+end

--- a/app/policies/team_policy.rb
+++ b/app/policies/team_policy.rb
@@ -1,0 +1,17 @@
+class TeamPolicy < ApplicationPolicy
+  def index?
+    user
+  end
+
+  def create?
+    user.manager?
+  end
+
+  def update?
+    user.manager?
+  end
+
+  def destroy?
+    user.manager?
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,14 @@
   <title>CyberVacations</title>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_include_tag 'application' %>
+  <% unless current_user.nil? %>
+  <script type="text/javascript">
+    window.App.currentUser = new App.Models.CurrentUser(
+      <%=raw(current_user.to_json(only: [:id,:first_name,:last_name])) %>
+    );
+    window.App.currentUserRoles = new App.Collections.CurrentUserRoles(<%=raw(current_user.team_roles.to_json(only: [:id,:role,:team_id])) %>);
+  </script>
+  <% end %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -31,10 +31,12 @@ RSpec.describe TeamsController do
 
   ################################################################# POST #create
   describe 'POST #create' do
-    let(:params)  { Hash[format: :json, team: Hash[:name, team.name]] }
-    let(:send_request) { post :create, params }
+    let(:another_team)  { FactoryGirl.create(:team, :with_users) }
+    let(:params)        { Hash[format: :json, team: Hash[:name, team.name]] }
+    let(:send_request)  { post :create, params }
 
-    context 'from authenticated user' do
+    context 'from authenticated user with manager role' do
+      let(:user) { another_team.team_roles.managers.first.user }
       before { sign_in user }
 
       context 'with correct data' do
@@ -91,9 +93,10 @@ RSpec.describe TeamsController do
 
   ################################################################## PUT #update
   describe 'PUT #update' do
-    let(:team) { FactoryGirl.create(:team) }
+    let(:team) { FactoryGirl.create(:team, :with_users) }
 
-    context 'from authenticated user' do
+    context 'from authenticated user with manager' do
+      let(:user) { team.team_roles.managers.first.user }
       before { sign_in user }
 
       context 'with correct data' do
@@ -172,9 +175,10 @@ RSpec.describe TeamsController do
 
   ################################################################ PATCH #update
   describe 'PATCH #update' do
-    let(:team) { FactoryGirl.create(:team) }
+    let(:team) { FactoryGirl.create(:team, :with_users) }
 
-    context 'from authenticated user' do
+    context 'from authenticated user with manager role' do
+      let(:user) { team.team_roles.managers.first.user }
       before { sign_in user }
 
       context 'with correct data' do
@@ -253,12 +257,15 @@ RSpec.describe TeamsController do
 
   ############################################################## DELETE #destroy
   describe 'DELETE #destroy' do
+    let(:team)          { FactoryGirl.create(:team, :with_users) }
     let(:params)        { Hash[format: :json, id: teams.first.id] }
     let(:send_request)  { delete :destroy, params }
 
     before { teams }
 
-    context 'from authenticated user' do
+    context 'from authenticated user with manager' do
+      let(:user) { team.team_roles.managers.first.user }
+
       before { sign_in user }
 
       it 'should respond with status code :no_content (204)' do

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,5 +1,35 @@
 FactoryGirl.define do
   factory :team do
-    name  'Hornets'
+    transient do
+      number_of_managers  1
+      number_of_members   3
+      number_of_guests    1
+    end
+
+    name  { "#{FFaker::Skill.tech_skill} team" }
+
+    trait :with_users do
+      after :create do |team, evaluator|
+        evaluator.number_of_managers.times do
+          user = FactoryGirl.create(:user)
+          FactoryGirl.create(:team_role, user: user, team: team, role: 'manager')
+        end
+        evaluator.number_of_members.times do
+          user = FactoryGirl.create(:user)
+          FactoryGirl.create(:team_role, user: user, team: team, role: 'member')
+        end
+        evaluator.number_of_guests.times do
+          user = FactoryGirl.create(:user)
+          FactoryGirl.create(:team_role, user: user, team: team, role: 'guest')
+        end
+      end
+    end
+
+    trait :with_manager_only do
+      after :create do |team|
+        user = FactoryGirl.create(:user)
+        FactoryGirl.create(:team_role, user: user, team: team, role: 'manager')
+      end
+    end
   end
 end

--- a/spec/features/guest_creates_a_team_spec.rb
+++ b/spec/features/guest_creates_a_team_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'Guest creates a team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team) { FactoryGirl.create(:team) }
+
+  background do
+    FactoryGirl.create(:team_role, user: user, team: team, role: 'guest')
+    sign_in_with user.email, user.password
+    click_on 'Teams'
+  end
+
+  scenario 'and fails due to authorization issue' do
+    expect(page).to have_content('Sign out')
+    expect(page).to     have_content(team.name)
+    expect(page).not_to have_selector('input[name="team-name"]')
+    expect(page).not_to have_selector('button[name="add"]')
+  end
+end

--- a/spec/features/guest_deletes_team_spec.rb
+++ b/spec/features/guest_deletes_team_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'Guest deletes team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team)          { FactoryGirl.create(:team) }
+  given(:another_team)  { FactoryGirl.create(:team) }
+
+  context 'with "guest" role in the team' do
+    background do
+      create(:team_role, user: user, team: team, role: 'guest')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      node = page.find('li', text: team.name)
+      # Does not provide action related control
+      expect(node).not_to have_css('input[type=button]')
+
+      expect(page).to     have_content(team.name)
+    end
+  end
+
+  context 'with "guest" role in another team, but not the subject one' do
+    background do
+      team
+      create(:team_role, user: user, team: another_team, role: 'guest')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      node = page.find('li', text: team.name)
+      # Does not provide action related control
+      expect(node).not_to have_css('input[type=button]')
+
+      expect(page).to     have_content(team.name)
+    end
+  end
+end

--- a/spec/features/guest_updates_team_spec.rb
+++ b/spec/features/guest_updates_team_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'Guest updates team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team)          { FactoryGirl.create(:team) }
+  given(:another_team)  { FactoryGirl.create(:team) }
+
+  context 'with "guest" role in the team' do
+    background do
+      create(:team_role, user: user, team: team, role: 'guest')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      page.find('li', text: team.name).double_click
+
+      # Does not respond to the event
+      expect(page).not_to have_css('.editing input')
+      expect(page).to     have_content(team.name)
+    end
+  end
+
+  context 'with "guest" role in another team, but not the subject one' do
+    background do
+      team
+      create(:team_role, user: user, team: another_team, role: 'guest')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      page.find('li', text: team.name).double_click
+
+      # Does not respond to the event
+      expect(page).not_to have_css('.editing input')
+      expect(page).to     have_content(team.name)
+    end
+  end
+end

--- a/spec/features/manager_creates_a_team_spec.rb
+++ b/spec/features/manager_creates_a_team_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Manager creates a team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team) { FactoryGirl.create(:team) }
+
+  background do
+    FactoryGirl.create(:team_role, user: user, team: team, role: 'manager')
+    sign_in_with user.email, user.password
+    click_on 'Teams'
+  end
+
+  context 'successfully, with valid input' do
+    scenario 'name=Valiants' do
+      team_name = 'Valiants'
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+      expect(page).not_to have_content(team_name)
+
+      fill_in 'team-name', with: team_name
+      click_button 'Add'
+
+      expect(page).to     have_content(team.name)
+      expect(page).to     have_content(team_name)
+    end
+  end
+
+  context 'unsuccessfully, with not valid input' do
+    scenario 'name=Ants' do
+      team_name = 'Ants'
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+      expect(page).not_to have_content(team_name)
+
+      fill_in 'team-name', with: team_name
+      click_button 'Add'
+
+      expect(page).to     have_content(team.name)
+      expect(page).not_to have_content(team_name)
+    end
+  end
+end

--- a/spec/features/manager_deletes_team_spec.rb
+++ b/spec/features/manager_deletes_team_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.feature 'Manager deletes team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team)          { FactoryGirl.create(:team) }
+  given(:another_team)  { FactoryGirl.create(:team) }
+
+  context 'with "manager" role in the team' do
+    background do
+      another_team
+      create(:team_role, user: user, team: team, role: 'manager')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'successfully' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+      expect(page).to     have_content(another_team.name)
+
+      node = page.find('li', text: team.name)
+      # Provides action related control
+      expect(node).to     have_css('input[type=button]')
+      node.find(:button, 'Delete').click
+
+      expect(page).not_to have_content(team.name)
+      expect(page).to     have_content(another_team.name)
+    end
+  end
+
+  context 'with "manager" role in another team, but not the subject one' do
+    background do
+      team
+      create(:team_role, user: user, team: another_team, role: 'manager')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'successfully' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+      expect(page).to     have_content(another_team.name)
+
+      node = page.find('li', text: team.name)
+      # Provides action related control
+      expect(node).to     have_css('input[type=button]')
+      node.find(:button, 'Delete').click
+
+      expect(page).not_to have_content(team.name)
+      expect(page).to     have_content(another_team.name)
+    end
+  end
+end

--- a/spec/features/manager_updates_team_spec.rb
+++ b/spec/features/manager_updates_team_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.feature 'Manager updates team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team)          { FactoryGirl.create(:team) }
+  given(:another_team)  { FactoryGirl.create(:team) }
+
+  context 'with "manager" role in the team' do
+    background do
+      create(:team_role, user: user, team: team, role: 'manager')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    context 'successfully, with valid input' do
+      scenario 'name=Valiants' do
+        team_name = 'Valiants'
+        expect(page).to have_content('Sign out')
+        expect(page).to     have_content(team.name)
+        expect(page).not_to have_content(team_name)
+
+        page.find('li', text: team.name).double_click
+        field = page.find(:css, '.editing input')
+        field.set team_name
+        field.native.send_key :Enter
+
+        expect(page).not_to have_content(team.name)
+        expect(page).to     have_content(team_name)
+      end
+    end
+
+    context 'unsuccessfully, with not valid input' do
+      scenario 'name=Ants' do
+        team_name = 'Ants'
+        expect(page).to have_content('Sign out')
+        expect(page).to     have_content(team.name)
+        expect(page).not_to have_content(team_name)
+
+        page.find('li', text: team.name).double_click
+        field = page.find(:css, '.editing input')
+        field.set team_name
+        field.native.send_key :Enter
+
+        expect(page).to     have_content(team.name)
+        expect(page).not_to have_content(team_name)
+      end
+    end
+  end
+
+  context 'with "manager" role in another team, but not the subject one' do
+    background do
+      team
+      create(:team_role, user: user, team: another_team, role: 'manager')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    context 'successfully, with valid input' do
+      scenario 'name=Valiants' do
+        team_name = 'Valiants'
+        expect(page).to have_content('Sign out')
+        expect(page).to     have_content(another_team.name)
+        expect(page).to     have_content(team.name)
+        expect(page).not_to have_content(team_name)
+
+        page.find('li', text: team.name).double_click
+        field = page.find(:css, '.editing input')
+        field.set team_name
+        field.native.send_key :Enter
+
+        expect(page).to     have_content(another_team.name)
+        expect(page).not_to have_content(team.name)
+        expect(page).to     have_content(team_name)
+      end
+    end
+
+    context 'unsuccessfully, with not valid input' do
+      scenario 'name=Ants' do
+        team_name = 'Ants'
+        expect(page).to have_content('Sign out')
+        expect(page).to     have_content(team.name)
+        expect(page).not_to have_content(team_name)
+
+        page.find('li', text: team.name).double_click
+        field = page.find(:css, '.editing input')
+        field.set team_name
+        field.native.send_key :Enter
+
+        expect(page).to     have_content(team.name)
+        expect(page).not_to have_content(team_name)
+      end
+    end
+  end
+end

--- a/spec/features/member_creates_a_team_spec.rb
+++ b/spec/features/member_creates_a_team_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'Member creates a team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team) { FactoryGirl.create(:team) }
+
+  background do
+    FactoryGirl.create(:team_role, user: user, team: team, role: 'member')
+    sign_in_with user.email, user.password
+    click_on 'Teams'
+  end
+
+  scenario 'and fails due to authorization issue' do
+    expect(page).to have_content('Sign out')
+    expect(page).to     have_content(team.name)
+    expect(page).not_to have_selector('input[name="team-name"]')
+    expect(page).not_to have_selector('button[name="add"]')
+  end
+end

--- a/spec/features/member_deletes_team_spec.rb
+++ b/spec/features/member_deletes_team_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.feature 'Member deletes team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team)          { FactoryGirl.create(:team) }
+  given(:another_team)  { FactoryGirl.create(:team) }
+
+  context 'with "member" role in the team' do
+    background do
+      create(:team_role, user: user, team: team, role: 'member')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      node = page.find('li', text: team.name)
+      # Does not provide action related control
+      expect(node).not_to have_css('input[type=button]')
+
+      expect(page).to     have_content(team.name)
+    end
+  end
+
+  context 'with "member" role in another team, but not the subject one' do
+    background do
+      team
+      create(:team_role, user: user, team: another_team, role: 'member')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      node = page.find('li', text: team.name)
+      # Does not provide action related control
+      expect(node).not_to have_css('input[type=button]')
+
+      expect(page).to     have_content(team.name)
+    end
+  end
+end

--- a/spec/features/member_updates_team_spec.rb
+++ b/spec/features/member_updates_team_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Member updates team', js: true do
+  given(:user) { FactoryGirl.create(:user) }
+  given(:team)          { FactoryGirl.create(:team) }
+  given(:another_team)  { FactoryGirl.create(:team) }
+
+  context 'with "member" role in the team' do
+    background do
+      create(:team_role, user: user, team: team, role: 'member')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      page.find('li', text: team.name).double_click
+
+      expect(page).not_to have_css('.editing input')
+      expect(page).to     have_content(team.name)
+    end
+  end
+
+  context 'with "member" role in another team, but not the subject one' do
+    background do
+      team
+      create(:team_role, user: user, team: another_team, role: 'member')
+      sign_in_with user.email, user.password
+      click_on 'Teams'
+    end
+
+    scenario 'unsuccessfully, due to authorization' do
+      expect(page).to have_content('Sign out')
+      expect(page).to     have_content(team.name)
+
+      page.find('li', text: team.name).double_click
+
+      expect(page).not_to have_css('.editing input')
+      expect(page).to     have_content(team.name)
+    end
+  end
+end

--- a/spec/features/user_sings_in_spec.rb
+++ b/spec/features/user_sings_in_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature 'User signs in' do
+  given(:user) { FactoryGirl.create(:user) }
+  scenario 'with valid email and password' do
+    sign_in_with user.email, user.password
+
+    expect(page).to have_content('Sign out')
+  end
+
+  scenario 'with invalid email, and fails' do
+    sign_in_with 'invalid_email', user.password
+
+    expect(page).to have_content('Sign in')
+  end
+
+  scenario 'with blank password, and fails' do
+    sign_in_with user.email, ''
+
+    expect(page).to have_content('Sign in')
+  end
+
+  def sign_in_with(email, password)
+    visit new_user_session_path
+    fill_in 'Email', with: email
+    fill_in 'Password', with: password
+    click_button 'Log in'
+  end
+end

--- a/spec/javascripts/views/team_spec.js
+++ b/spec/javascripts/views/team_spec.js
@@ -1,31 +1,17 @@
 describe('Team view', function() {
-
-  describe('as a brand new object', function() {
-    beforeEach(function() {
-      this.view = new App.Views.Team();
-    });
-
-    afterEach(function() {
-      this.view.remove();
-    });
-
-    it('has its .model attribute undefined', function() {
-      expect(this.view.model).toBeUndefined();
-    });
-
-    it('has its .className properly set', function() {
-      expect(this.view.el.className).toBe('list-group-item');
-    });
-
-    it('has its .outerHTML properly set', function() {
-      expect(this.view.el.outerHTML).toBe('<li class="list-group-item"></li>');
-    });
+  beforeEach(function() {
+    // Stub User roles
+    App.currentUserRoles = new App.Collections.CurrentUserRoles([
+      {'id':1, 'team_id':1, 'role':'manager'}
+    ]);
   });
 
   describe('as a real object', function() {
     beforeEach(function() {
-      this.model = new App.Models.Team();
-      this.model.set('name', 'Angrybirds');
+      this.model = new App.Models.Team({
+        'id':   1,
+        'name': 'Angrybirds'
+      });
       this.view = new App.Views.Team({'model': this.model});
 
       setFixtures('<ul class="teams-list"></ul>');
@@ -80,7 +66,7 @@ describe('Team view', function() {
 
       it('click .remove', function() {
         this.deleteButton = this.container.find('li .remove');
-        spyOn(this.view, 'onRemove').and.callThrough();
+        spyOn(this.view, 'onRemove');
         this.view.delegateEvents();
 
         this.deleteButton.trigger('click');

--- a/spec/javascripts/views/teams_spec.js
+++ b/spec/javascripts/views/teams_spec.js
@@ -7,6 +7,11 @@ describe('Teams view', function() {
       {'name':'Angrybirds'}
     ]);
 
+    // Stub User roles
+    App.currentUserRoles = new App.Collections.CurrentUserRoles([
+      {'id':1, 'role':'manager'}
+    ]);
+
     this.view = new App.Views.Teams({'collection':collection});
     this.view.render();
     this.container = $('#teams');

--- a/spec/models/team_role_spec.rb
+++ b/spec/models/team_role_spec.rb
@@ -35,6 +35,33 @@ RSpec.describe TeamRole do
       .to raise_exception(ActiveRecord::RecordInvalid)
   end
 
+  describe '.managers' do
+    let(:team) { FactoryGirl.create(:team, :with_users, number_of_managers: 1) }
+
+    it 'provides list of users with "manager" role' do
+      expect(TeamRole).to respond_to(:managers)
+      expect(team.team_roles.managers.count).to eq(1)
+    end
+  end
+
+  describe '.members' do
+    let(:team) { FactoryGirl.create(:team, :with_users, number_of_members: 1) }
+
+    it 'provides list of users with "member" role' do
+      expect(TeamRole).to respond_to(:members)
+      expect(team.team_roles.members.count).to eq(1)
+    end
+  end
+
+  describe '.guests' do
+    let(:team) { FactoryGirl.create(:team, :with_users, number_of_guests: 1) }
+
+    it 'provides list of users with "guest" role' do
+      expect(TeamRole).to respond_to(:guests)
+      expect(team.team_roles.guests.count).to eq(1)
+    end
+  end
+
   context 'validations' do
     it { should define_enum_for(:role) }
 

--- a/spec/policies/team_policy_spec.rb
+++ b/spec/policies/team_policy_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe TeamPolicy do
+  let(:team)          { create(:team, :with_users, number_of_members: 1) }
+  let(:another_team)  { create(:team, :with_users, number_of_members: 1) }
+
+  subject { TeamPolicy }
+
+  permissions :create?, :update?, :destroy? do
+    context 'for the team members' do
+      let(:manager) { team.team_roles.managers.first.user }
+      let(:member)  { team.team_roles.members.first.user }
+      let(:guest)   { team.team_roles.guests.first.user }
+
+      context 'with role=manager' do
+        it 'grants access' do
+          expect(subject).to permit(manager, team)
+        end
+      end
+      context 'with role=member, or role=guest' do
+        it 'denies access' do
+          expect(subject).not_to permit(member, team)
+          expect(subject).not_to permit(guest, team)
+        end
+      end
+    end
+
+    context 'for members of another team' do
+      let(:manager) { another_team.team_roles.managers.first.user }
+      let(:member)  { another_team.team_roles.members.first.user }
+      let(:guest)   { another_team.team_roles.guests.first.user }
+
+      context 'with role=manager' do
+        it 'grants access' do
+          expect(subject).to permit(manager, team)
+        end
+      end
+      context 'with role=member, or role=guest' do
+        it 'denies access' do
+          expect(subject).not_to permit(member, team)
+          expect(subject).not_to permit(guest, team)
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,17 +6,35 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'shoulda/matchers'
+require 'pundit/rspec'
 require 'ffaker'
+require 'database_cleaner'
+require 'capybara/poltergeist'
 
 ActiveRecord::Migration.maintain_test_schema!
+Capybara.javascript_driver = :poltergeist
 
 RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
+  config.include Features::SessionHelpers, type: :feature
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   config.infer_spec_type_from_file_location!
   config.include FactoryGirl::Syntax::Methods
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do |example|
+    DatabaseCleaner.strategy= example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -1,0 +1,10 @@
+module Features
+  module SessionHelpers
+    def sign_in_with(email, password)
+      visit new_user_session_path
+      fill_in 'Email', with: email
+      fill_in 'Password', with: password
+      click_button 'Log in'
+    end
+  end
+end


### PR DESCRIPTION
The aim of the feature tests is to check Team related behavior from user
point of view. Additional changes in code are provided as well as
authorization abstraction layer with Pundit in Rails part, and custom
workaround in BB part.
User abilities to create, update, and destroy teams depend on provided
privileges which are determined by roles.
User with the manager role in any team is able to create, update,
and destroy any team.

Integrate the following tools:
  - Capybara
  - Database Cleaner
  - Poltergeist
  - Pundit

Add the following feature specs:
  - Guest creates a team
  - Guest updates team
  - Guest deletes team
  - Manager creates a team
  - Manager updates team
  - Manager deletes team
  - Member creates a team
  - Member updates team
  - Member deletes team
  - User signs in

Add TeamPolicy authorization
  Create authorization rules for the TeamsController.
  Update all related tests accordingly.
  Add policy tests.

Fixes:
  - Update Jasmine tests for Team view and Teams view to stub
    user related info.

Improvements:
  - Rework BB current user handling
    The main idea is to pass current user information within HTML layout.
    This assumes that a user, once logged in, is not changed.
  - Update BB `CurrentUserRoles` collection to provide user privileges
  - Update BB `Teams` view to consider user privileges
  - Add the following scopes into `TeamRole` model:
      - `managers`, to get team members with role `manager`;
      - `members`,  to get team members with role `member`;
      - `guests`,   to get team members with role `guests`.
  - Add `with_users` trait into Teams factory
    The idea is to create a team with users attached to the team with
    particular roles.
    By default a team with the following structure is created:
      - 1 manager
      - 3 members
      - 1 guest
    The behavior is configured with new factory transients.
  - Add `#manager_of?` method to `User` model
  - Handle Pundit related exceptions with proper HTTP status code.
  - Add the following authorization methods to the `User` model
    to figure out whether user has manager role:
      - `manager?`,     in any team;
      - `manager_of?`,  in particular team.
  - Update `Team` model with `dependent: :destroy`
  - Update BB `Team` view to consider user privileges

Refactoring:
  - Extract `sign_in_with()` as an RSpec helper
  - Rename transient attributes in Team factory

@alazarchuk , @epmlys , @JosephBuchma , @rubycop 