### PR TITLE
Update VacationRequest model validation

### DIFF
--- a/app/assets/javascripts/models/vacation_request.js
+++ b/app/assets/javascripts/models/vacation_request.js
@@ -6,7 +6,6 @@ App.Models.VacationRequest = Backbone.Model.extend({
     'start_date':'',
     'planned_end_date':'',
     'actual_end_date':'',
-    'user_id': 0
   },
 
   get: function(attribute) {
@@ -22,9 +21,9 @@ App.Models.VacationRequest = Backbone.Model.extend({
         expected_keys = _.keys(this.defaults),
         forbidden_keys = [];
 
-    // The ID is not expected by backend in case of a new record,
-    // but it is Ok to initialize the attribute as well, if needed.
-    expected_keys.push('id');
+    // Attributes that are not expected by backend in case of a new record,
+    // but it is Ok to initialize a model with these attributes.
+    expected_keys.push('id', 'user_id');
 
     if (_.isObject(arguments[0])) {
       options = _.extend(options, arguments[1]);

--- a/app/assets/javascripts/views/vacation_request_form.js
+++ b/app/assets/javascripts/views/vacation_request_form.js
@@ -15,7 +15,8 @@ App.Views.VacationRequestForm = Backbone.View.extend({
     this.availableVacations = options.availableVacations;
     this.model = new App.Models.VacationRequest();
 
-    this.listenTo(this.holidays, 'sync',  this.render);
+    this.listenTo(this.holidays,  'sync',   this.render);
+    this.listenTo(this.model,     'error',  this.onError);
   },
 
   render: function() {
@@ -29,6 +30,11 @@ App.Views.VacationRequestForm = Backbone.View.extend({
   onClear: function(event) {
     this.$('input[name=from]').val('').trigger('change').datepicker('update');
     this.$('input[name=to]').val('').trigger('change').datepicker('update');
+  },
+
+  onError: function(model, response, options) {
+    // TODO: show error messages to user
+    // console.log(response.responseJSON.errors.base);
   },
 
   onFromChange: function(event) {

--- a/app/models/vacation_request.rb
+++ b/app/models/vacation_request.rb
@@ -2,12 +2,12 @@ class VacationRequest < ActiveRecord::Base
   belongs_to  :user
   has_many    :approval_requests
 
-  validates :kind, :planned_end_date, :start_date, :status, :user,
+  validate :cannot_intersect_with_other_vacations
+  validates :actual_end_date, :kind, :planned_end_date,
+            :status, :start_date, :user,
             presence: true
-  validates :actual_end_date,
-            presence: true,
-            inclusion: { in: Date.new(2015, 01, 01)..Date.new(2115, 01, 01) },
-            if: "status == 'used'"
+  validates :actual_end_date, :planned_end_date,
+            inclusion: { in: Date.new(2015, 01, 01)..Date.new(2115, 01, 01) }
 
   scope :requested_accepted_inprogress, lambda {
     where(status: [VacationRequest.statuses[:requested],
@@ -36,4 +36,39 @@ class VacationRequest < ActiveRecord::Base
     :unpaid,
     :sickness
   ]
+
+  def cannot_intersect_with_other_vacations
+    number_of_records  = number_of_intersected_records
+    number_of_records += number_of_records_that_include_vacation
+
+    errors.add(:base, 'cannot inresect with other vacations')\
+      if number_of_records > 0
+  end
+
+private
+
+  # Number of records that somehow intersect with the vacation
+  # For example, the vacation '2015-09-01'..'2015-09-10'
+  # intersects with the following vacations:
+  #   - '2015-09-05'..'2015-09-15', by '2015-09-05'
+  #   - '2015-08-25'..'2015-09-10', by '2015-09-10'
+  #   - '2015-09-05'..'2015-09-09', by both
+  # The last vacation is actually included by the vacation in subject.
+  def number_of_intersected_records
+    VacationRequest.where(
+      VacationRequest.where(start_date: start_date..actual_end_date)
+        .where(actual_end_date: start_date..actual_end_date)
+        .where_values
+        .reduce(:or)
+    ).where(user_id: user_id).count
+  end
+
+  # Number of records that includes the vacation
+  # For example, the vacation '2015-09-01'..'2015-09-20'
+  # includes the subject vacation '2015-09-05'..'2015-09-15'
+  def number_of_records_that_include_vacation
+    VacationRequest.where('start_date <= ?', start_date)
+      .where('actual_end_date >= ?', actual_end_date)
+      .where(user_id: user_id).count
+  end
 end

--- a/app/models/vacation_request.rb
+++ b/app/models/vacation_request.rb
@@ -40,7 +40,7 @@ class VacationRequest < ActiveRecord::Base
   def cannot_intersect_with_other_vacations
     number_of_records  = number_of_intersected_records
 
-    errors.add(:base, 'cannot inresect with other vacations')\
+    errors.add(:base, 'cannot intersect with other vacations')\
       if number_of_records > 0
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -51,4 +51,4 @@
         %section
           = yield
         %footer
-          Copyright © CyberCraft 2015
+          © 2015 CyberCraft Inc.

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,10 +9,11 @@ FactoryGirl.define do
       start_date = Time.zone.today
       after :create do |user|
         VacationRequest.statuses.each_value do |status|
-          start_date += 2.days
+          start_date += 3.days
           FactoryGirl.create  :vacation_request,
                               status: status,
                               start_date: start_date,
+                              planned_end_date: start_date + 2.days,
                               user: user
         end
       end

--- a/spec/factories/vacation_requests.rb
+++ b/spec/factories/vacation_requests.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :vacation_request do
     kind    'planned'
-    start_date        '2015-02-28'
+    start_date        { Time.zone.now }
     planned_end_date  { (Date.parse(start_date.to_s) + 2.days).to_s }
     actual_end_date   { planned_end_date }
     status  'requested'

--- a/spec/models/vacation_request_spec.rb
+++ b/spec/models/vacation_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe VacationRequest do
 
     it { expect(vacation_request).to have_attributes kind: 'planned' }
     it { expect(vacation_request).to have_attributes status: 'requested' }
-    it { expect(vacation_request).to have_attributes actual_end_date: nil }
+    it { expect(vacation_request).to have_attributes planned_end_date: nil }
     it { expect(vacation_request).to have_attributes planned_end_date: nil }
     it { expect(vacation_request).to have_attributes start_date: nil }
     it { expect(vacation_request).to have_attributes user_id: nil }
@@ -34,21 +34,188 @@ RSpec.describe VacationRequest do
   end
 
   describe 'with "status=used"' do
-    it 'does not allow to pass "actual_end_date" as incorrect date string' do
+    it 'does not allow to pass "planned_end_date" as incorrect date string' do
       vacation_request = build(:vacation_request, :invalid, status: 'used')
 
       expect(vacation_request).not_to be_valid
     end
   end
 
-  describe '.duration' do
-    pending 'To be implemented'
-    # let(:user) { create :user, :with_vacations_of_all_statuses }
-    #
-    # it 'provides accordingly filtered list of vacation requests' do
-    #   expect(user.vacation_requests.count).to eq(6)
-    #   expect(VacationRequest.requested_accepted_inprogress.count).to eq(3)
-    # end
+  describe '.cannot_intersect_with_other_vacations' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:another_user) { FactoryGirl.create(:user) }
+    let(:vacation_request) { FactoryGirl.build(:vacation_request) }
+
+    before do
+      vacation_request.start_date        = '2015-09-01'
+      vacation_request.planned_end_date  = '2015-09-21'
+      vacation_request.actual_end_date   = vacation_request.planned_end_date
+      vacation_request.user = user
+      vacation_request.validate
+    end
+
+    describe 'for the very first vacation request' do
+      it 'does not set any errors' do
+        expect(vacation_request.errors).to be_empty
+        expect(vacation_request).to be_valid
+      end
+    end
+
+    context 'when user has other vacation requests' do
+      describe 'without intersections' do
+        before do
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-08-22', planned_end_date: '2015-08-30')
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-09-22', planned_end_date: '2015-09-25')
+
+          vacation_request.validate
+        end
+
+        it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+
+      describe 'with intersections on start bound' do
+        before do
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-08-22', planned_end_date: '2015-09-01')
+
+          vacation_request.validate
+        end
+
+        it 'sets error' do
+          expect(vacation_request.errors).not_to be_empty
+          expect(vacation_request).not_to be_valid
+        end
+      end
+
+      describe 'with intersections on end bound' do
+        before do
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-09-21', planned_end_date: '2015-09-25')
+
+          vacation_request.validate
+        end
+
+        it 'sets error' do
+          expect(vacation_request.errors).not_to be_empty
+          expect(vacation_request).not_to be_valid
+        end
+      end
+
+      describe 'with intersections on both bounds' do
+        before do
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-08-22', planned_end_date: '2015-09-01')
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-09-21', planned_end_date: '2015-09-25')
+
+          vacation_request.validate
+        end
+
+        it 'sets error' do
+          expect(vacation_request.errors).not_to be_empty
+          expect(vacation_request).not_to be_valid
+        end
+      end
+
+      describe 'with inner intersections' do
+        before do
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-09-05', planned_end_date: '2015-09-15')
+
+          vacation_request.validate
+        end
+
+        it 'sets error' do
+          expect(vacation_request.errors).not_to be_empty
+          expect(vacation_request).not_to be_valid
+        end
+      end
+    end
+
+    context 'when another user has vacation requests' do
+      describe 'without intersections' do
+        before do
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-08-22', planned_end_date: '2015-08-30')
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-09-22', planned_end_date: '2015-09-25')
+        end
+
+        it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+
+      describe 'with intersections on start bound' do
+        before do
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-08-22', planned_end_date: '2015-09-01')
+        end
+
+        it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+
+      describe 'with intersections on end bound' do
+        before do
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-09-21', planned_end_date: '2015-09-25')
+        end
+
+        it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+
+      describe 'with intersections on both bounds' do
+        before do
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-08-22', planned_end_date: '2015-09-01')
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-09-21', planned_end_date: '2015-09-25')
+        end
+
+        it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+
+      describe 'with inner intersections' do
+        before do
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-09-05', planned_end_date: '2015-09-15')
+        end
+
+        it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+    end
   end
 
   describe '.requested_accepted_inprogress' do
@@ -80,10 +247,29 @@ RSpec.describe VacationRequest do
     it { should define_enum_for(:kind) }
     it { should define_enum_for(:status) }
 
+    it { should validate_presence_of(:actual_end_date) }
     it { should validate_presence_of(:kind) }
-    it { should validate_presence_of(:start_date) }
+    it { should validate_presence_of(:planned_end_date) }
     it { should validate_presence_of(:status) }
+    it { should validate_presence_of(:start_date) }
     it { should validate_presence_of(:user) }
+
+    it 'should ensure inclusion of actual_end_date in proper range' do
+      vacation_request = build(:vacation_request)
+      vacation_request.actual_end_date = '2014-12-31'
+      expect(vacation_request).to be_invalid
+
+      vacation_request.actual_end_date = '2115-12-31'
+      expect(vacation_request).to be_invalid
+
+      vacation_request.actual_end_date = '2055-12-31'
+      expect(vacation_request).to be_valid
+    end
+
+    it do
+      should validate_inclusion_of(:planned_end_date)
+        .in_range(Date.new(2015, 01, 01)..Date.new(2115, 01, 01))
+    end
   end
 
   context 'associations' do

--- a/spec/models/vacation_request_spec.rb
+++ b/spec/models/vacation_request_spec.rb
@@ -128,11 +128,26 @@ RSpec.describe VacationRequest do
         end
       end
 
-      describe 'with inner intersections' do
+      describe 'with inner intersection' do
         before do
           create(:vacation_request,
                  user: user,
                  start_date: '2015-09-05', planned_end_date: '2015-09-15')
+
+          vacation_request.validate
+        end
+
+        it 'sets error' do
+          expect(vacation_request.errors).not_to be_empty
+          expect(vacation_request).not_to be_valid
+        end
+      end
+
+      describe 'with outer intersection' do
+        before do
+          create(:vacation_request,
+                 user: user,
+                 start_date: '2015-08-30', planned_end_date: '2015-09-25')
 
           vacation_request.validate
         end
@@ -203,7 +218,7 @@ RSpec.describe VacationRequest do
         end
       end
 
-      describe 'with inner intersections' do
+      describe 'with inner intersection' do
         before do
           create(:vacation_request,
                  user: another_user,
@@ -211,6 +226,21 @@ RSpec.describe VacationRequest do
         end
 
         it 'does not set any errors' do
+          expect(vacation_request.errors).to be_empty
+          expect(vacation_request).to be_valid
+        end
+      end
+
+      describe 'with outer intersection' do
+        before do
+          create(:vacation_request,
+                 user: another_user,
+                 start_date: '2015-08-30', planned_end_date: '2015-09-25')
+
+          vacation_request.validate
+        end
+
+        it 'sets error' do
           expect(vacation_request.errors).to be_empty
           expect(vacation_request).to be_valid
         end


### PR DESCRIPTION
The VacationRequest model implements validation method
`cannot_intersect_with_other_vacations()` that looks into DB and checks
if there are any records that intersect with the new record.
There must be no records that have days from the period of the new
vacation request.

Update factory for users so that it generates valid vacation requests

Update factory for vacation requests so that it initialize `start_date`
property dynamically, that is, with the `Time.zone.now()` method.

Update tests for VacationRequest model
Test `VacationRequest#cannot_intersect_with_other_vacations` method.
Rework test for validation of inclusion of `actual_end_date` property in
permitted date range.

Update BB VacationRequest model
Move the `user_id` attribute from the list of defaults to the list
of expected attributes.

Update BB VacationRequestForm view
Add listener for the `error` event on VacationRequest model.

Update copyright statement

@alazarchuk , @rubycop , @epmlys 