### PR TITLE
Create BB VacationRequests view

### DIFF
--- a/app/assets/javascripts/models/vacation_request.js
+++ b/app/assets/javascripts/models/vacation_request.js
@@ -23,7 +23,7 @@ App.Models.VacationRequest = Backbone.Model.extend({
 
     // Attributes that are not expected by backend in case of a new record,
     // but it is Ok to initialize a model with these attributes.
-    expected_keys.push('id', 'user_id');
+    expected_keys.push('id', 'user_id', 'created_at', 'updated_at');
 
     if (_.isObject(arguments[0])) {
       options = _.extend(options, arguments[1]);

--- a/app/assets/javascripts/routers/router.js
+++ b/app/assets/javascripts/routers/router.js
@@ -1,15 +1,10 @@
-// Support for triggering `before` and `after` events inside BB's `route` method.
-// http://stackoverflow.com/questions/7394695/backbone-js-call-method-before-after-a-route-is-fired
-
 App.Router = Backbone.Router.extend({
   routes: {
     'dashboard':              'dashboard',
     'teams':                  'teams',
-    'new_vacation_request':   'new_vacation_request',
-    'vacation_requests_list': 'vacation_requests_list',
+    'vacation_requests':      'vacation_requests',
     'vacation_request/:id':   'vacation_request_details',
     'holidays':               'holidays',
-    'calendar':               'calendar',
   },
 
   dashboard: function() {
@@ -24,35 +19,34 @@ App.Router = Backbone.Router.extend({
   },
 
   teams: function() {
-    $('.content').html("You should see the list for Teams... that's all I can tell you, dude O_O");
+    $('.content').html("You should see the list for Teams...");
     var collection = new App.Collections.Teams();
     App.teams = new App.Views.Teams({'collection':collection});
     collection.fetch();
   },
 
-  new_vacation_request: function() {
+  vacation_requests: function() {
     var holidays = new App.Collections.Holidays(),
+        vacationRequests = new App.Collections.VacationRequests(),
         availableVacations = new App.Collections.AvailableVacations();
 
-    $('.content').html("You should see the <strong>New Vacation Request</strong> form...");
-
-    App.newVacationRequest = new App.Views.VacationRequestForm({
+    App.vacation_requests = new App.Views.VacationRequests({
       'holidays': holidays,
+      'vacationRequests': vacationRequests,
       'availableVacations': availableVacations
     });
-    // Ensure that all requests are complete
-    availableVacations.fetch().then(function() {
-      holidays.fetch();
-    });
-  },
 
-  vacation_requests_list: function() {
-    $('.content').html("You should see the <strong>List of Requests</strong>... that's all I can tell you, dude O_O");
-    App.vacation_requests = new App.Views.VacationRequestsList();
+    availableVacations.fetch()
+      .then(function() {
+        holidays.fetch();
+      })
+      .then(function() {
+        vacationRequests.fetch();
+      });
   },
 
   vacation_request_details: function( id ) {
-    $('.content').html("You should see the <strong>Vacation Request Details</strong>... that's all I can tell you, dude O_O");
+    $('.content').html("You should see the <strong>Vacation Request Details</strong>...");
     App.vacation_request_details = new App.Views.VacationRequestDetails({modelID:id});
   },
 
@@ -61,9 +55,5 @@ App.Router = Backbone.Router.extend({
     var collection = new App.Collections.Holidays();
     App.holidays = new App.Views.Holidays({'collection':collection});
     collection.fetch();
-  },
-
-  calendar: function() {
-    $('.content').html("Just a stub for the future Calendar...");
   }
 });

--- a/app/assets/javascripts/templates/vacation_request_form.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_request_form.jst.hamljs
@@ -1,22 +1,18 @@
-.panel.panel-primary
-  .panel-heading Request New Vacation
-  .panel-body
-    .new-vacation-request
-      .form.form-inline{role:'form'}
-        .col-md-5
-          .btn-group{data-toggle:'buttons'}
-            :each item in availableVacations
-              .btn.btn-default
-                %input{type:'radio', name:'vacation-type', value:item.attributes.kind}
-                #{item.attributes.kind} &nbsp;
-                .badge{class:item.attributes.kind}= item.attributes.available_days
-        .col-md-4
-          .input-group.input-daterange
-            %input.form-control{type:'text', name:'from', title:'Date of the holiday start'}
-            .input-group-addon to
-            %input.form-control{type:'text', name:'to',   title:'Date of the holiday end'}
-        .col-md-3
-          .pull-right
-            .btn-group
-              %button.btn.btn-default{name:'clear'}   Clear form
-              %button.btn.btn-default{name:'request'} Request
+.form.form-inline{role:'form'}
+  .col-md-5
+    .btn-group{data-toggle:'buttons'}
+      :each item in availableVacations
+        .btn.btn-default
+          %input{type:'radio', name:'vacation-type', value:item.attributes.kind}
+          #{item.attributes.kind} &nbsp;
+          .badge{class:item.attributes.kind}= item.attributes.available_days
+  .col-md-4
+    .input-group.input-daterange
+      %input.form-control{type:'text', name:'from', title:'Date of the holiday start'}
+      .input-group-addon to
+      %input.form-control{type:'text', name:'to',   title:'Date of the holiday end'}
+  .col-md-3
+    .pull-right
+      .btn-group
+        %button.btn.btn-default{name:'clear'}   Clear form
+        %button.btn.btn-default{name:'request'} Request

--- a/app/assets/javascripts/templates/vacation_requests.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_requests.jst.hamljs
@@ -1,0 +1,9 @@
+:if highestPrivilege !== 'guest'
+  .panel.panel-primary
+    .panel-heading Request New Vacation
+    .panel-body
+      .new-vacation-request-form
+.panel.panel-primary
+  .panel-heading List of Vacations
+  .panel-body
+    .vacation-requests-list

--- a/app/assets/javascripts/templates/vacation_requests_list.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_requests_list.jst.hamljs
@@ -1,33 +1,27 @@
-.panel.panel-primary
-  .panel-heading List of Vacations
-  .panel-body
-    %form
-      .row
-        .col-md-4
-          .input-group
-            %label.input-group-addon{for:'from'} From:
-            %input.form-control{type:'date', name:'from',  placeholder:'yyyy-mm-dd'}
-
-        .col-md-4
-          .input-group
-            %label.input-group-addon{for:'to'} To:
-            %input.form-control{type:'date', name:'to',    placeholder:'yyyy-mm-dd'}
-
-        .col-md-4
-          .input-group
-            %label.input-group-addon{for:'vacation-status'} Status:
-            %select.form-control{name:'vacation-status', multiple:true}
-              %option{value:'requested'}  requested
-              %option{value:'accepted'}   accepted
-              %option{value:'declined'}   declined
-              %option{value:'cancelled'}  cancelled
-              %option{value:'inprogress'} inprogress
-              %option{value:'used'}       used
-
-    %table.table.table-condesed.vacation-requests
-      %thead
-        %tr
-          %th Date range
-          %th Status
-          %th &nbsp;
-      %tbody
+%form
+  .row
+    .col-md-4
+      .input-group
+        %label.input-group-addon{for:'from'} From:
+        %input.form-control{type:'date', name:'from',  placeholder:'yyyy-mm-dd'}
+    .col-md-4
+      .input-group
+        %label.input-group-addon{for:'to'} To:
+        %input.form-control{type:'date', name:'to',    placeholder:'yyyy-mm-dd'}
+    .col-md-4
+      .input-group
+        %label.input-group-addon{for:'vacation-status'} Status:
+        %select.form-control{name:'vacation-status', multiple:true}
+          %option{value:'requested'}  requested
+          %option{value:'accepted'}   accepted
+          %option{value:'declined'}   declined
+          %option{value:'cancelled'}  cancelled
+          %option{value:'inprogress'} inprogress
+          %option{value:'used'}       used
+%table.table.table-condesed.vacation-requests
+  %thead
+    %tr
+      %th Date range
+      %th Status
+      %th &nbsp;
+  %tbody

--- a/app/assets/javascripts/views/vacation_request_form.js
+++ b/app/assets/javascripts/views/vacation_request_form.js
@@ -1,5 +1,5 @@
 App.Views.VacationRequestForm = Backbone.View.extend({
-  el: 'section',
+  el: '.new-vacation-request-form',
   template: JST['templates/vacation_request_form'],
 
   events: {
@@ -12,17 +12,18 @@ App.Views.VacationRequestForm = Backbone.View.extend({
 
   initialize: function(options) {
     this.holidays = options.holidays;
+    this.vacationRequests = options.vacationRequests;
     this.availableVacations = options.availableVacations;
     this.model = new App.Models.VacationRequest();
 
-    this.listenTo(this.holidays,  'sync',   this.render);
-    this.listenTo(this.model,     'error',  this.onError);
+    this.listenTo(this.model, 'sync', this.onSuccess);
+    this.listenTo(this.model, 'error', this.onError);
   },
 
   render: function() {
     this.$el.html(this.template({'availableVacations':this.availableVacations.models}));
     App.Helpers.assignDatePicker($('.input-daterange'));
-    this.$('input[value='+this.model.get('kind')+']').trigger('click');
+    this.$('input:radio[value='+this.model.get('kind')+']').trigger('click');
 
     return this;
   },
@@ -30,11 +31,6 @@ App.Views.VacationRequestForm = Backbone.View.extend({
   onClear: function(event) {
     this.$('input[name=from]').val('').trigger('change').datepicker('update');
     this.$('input[name=to]').val('').trigger('change').datepicker('update');
-  },
-
-  onError: function(model, response, options) {
-    // TODO: show error messages to user
-    // console.log(response.responseJSON.errors.base);
   },
 
   onFromChange: function(event) {
@@ -85,4 +81,15 @@ App.Views.VacationRequestForm = Backbone.View.extend({
       $button.addClass('btn-default');
     }
   },
+
+  onError: function(model, response, options) {
+    // TODO: show error messages to user
+    // console.log(response.responseJSON.errors.base);
+  },
+
+  onSuccess: function(model, response, options) {
+    // Trigger 'sync' on the collection to inform it's view,
+    // VacationRequestsList, about changes.
+    this.vacationRequests.fetch();
+  }
 });

--- a/app/assets/javascripts/views/vacation_requests.js
+++ b/app/assets/javascripts/views/vacation_requests.js
@@ -1,0 +1,29 @@
+App.Views.VacationRequests = Backbone.View.extend({
+  el: 'section',
+  template: JST['templates/vacation_requests'],
+
+  initialize: function(options) {
+    this.options = options;
+    this.data = {
+      highestPrivilege: App.currentUserRoles.highestPrivilege()
+    };
+
+    this.listenToOnce(this.options.vacationRequests, 'sync',  this.render);
+  },
+
+  render: function() {
+    this.$el.html(this.template(this.data));
+
+    this.vacationRequestForm = new App.Views.VacationRequestForm({
+      'holidays': this.options.holidays,
+      'vacationRequests': this.options.vacationRequests,
+      'availableVacations': this.options.availableVacations,
+    }).render();
+
+    this.vacationRequestsList = new App.Views.VacationRequestsList({
+      'vacationRequests': this.options.vacationRequests,
+    }).render();
+
+    return this;
+  }
+});

--- a/app/assets/javascripts/views/vacation_requests_list.js
+++ b/app/assets/javascripts/views/vacation_requests_list.js
@@ -1,5 +1,5 @@
 App.Views.VacationRequestsList = Backbone.View.extend({
-  el: 'section',
+  el: '.vacation-requests-list',
   template: JST['templates/vacation_requests_list'],
 
   events: {
@@ -8,25 +8,31 @@ App.Views.VacationRequestsList = Backbone.View.extend({
     'change input[name=to]':                'onDateTo',
   },
 
-  initialize: function() {
-    this.$el.html(this.template());
-    this.collection = new App.Collections.VacationRequests();
-    // Prepare handy access for the controls
-    this.$table     = this.$('table.vacation-requests');
-    this.$tableRows = this.$('table.vacation-requests tbody');
-    this.$select    = this.$('select[name=vacation-status]');
-    this.$from      = this.$('input[name=from]');
-    this.$to        = this.$('input[name=to]');
+  initialize: function(options) {
+    this.collection = options.vacationRequests;
 
-    this.listenTo(this.collection,  'sync',  this.render);
+    this.listenTo(this.collection, 'sync',  this.renderTable);
 
-    this.collection.fetch();
     this.statusFilter = null;
     this.dateFrom = null;
     this.dateTo   = null;
   },
 
   render: function() {
+    this.$el.html(this.template());
+
+    this.$table     = this.$('table.vacation-requests');
+    this.$tableRows = this.$('table.vacation-requests tbody');
+    this.$select    = this.$('select[name=vacation-status]');
+    this.$from      = this.$('input[name=from]');
+    this.$to        = this.$('input[name=to]');
+
+    this.renderTable();
+
+    return this;
+  },
+
+  renderTable: function() {
     var numberOfVisibleVacations = 0;
     this.$tableRows.empty();
     // Hide empty table
@@ -43,27 +49,27 @@ App.Views.VacationRequestsList = Backbone.View.extend({
     if (numberOfVisibleVacations > 0) {
       this.$table.show();
     }
-
-    return this;
   },
 
-  onStatusChange: function( e ) {
+  onStatusChange: function(event) {
     this.statusFilter = this.$select.val();
-    this.render();
+    this.renderTable();
   },
 
-  onDateFrom: function( e ) {
+  onDateFrom: function(event) {
     this.dateFrom = this.$from.val();
     this.render();
   },
 
-  onDateTo: function( e ) {
+  onDateTo: function(event) {
     this.dateTo = this.$to.val();
     this.render();
   },
 
   // Convert date's string into it's miliseconds representation
-  dateToMS: function( date ) {
+  // TODO: refactor the following code to use just Date objects
+  // as they are comparable by default.
+  dateToMS: function(date) {
     var dateInMS = (new Date(date)).getTime();
 
     var result = date ? dateInMS : 0;
@@ -71,12 +77,12 @@ App.Views.VacationRequestsList = Backbone.View.extend({
   },
 
   // Check if given model should be visible
-  isVacationVisible: function( model ) {
+  isVacationVisible: function(model) {
     var isVisible = false;
     // Calculate date in miliseconds to compare later
     var dateFrom  = this.dateToMS(this.dateFrom);
     var dateTo    = this.dateToMS(this.dateTo);
-    var modelFrom = this.dateToMS(model.get('start'));
+    var modelFrom = this.dateToMS(model.get('start_date'));
 
     var hasProperStatus = _.include(this.statusFilter, model.get('status'));
     var hasProperDateRange = (modelFrom >= dateFrom) && ((modelFrom <= dateTo) || (dateTo === 0));

--- a/app/controllers/vacation_requests_controller.rb
+++ b/app/controllers/vacation_requests_controller.rb
@@ -19,10 +19,11 @@ class VacationRequestsController < ApplicationController
     change_status!(managers_ids)
 
     if @vacation_request.save && create_approval_request(managers_ids)
-      head status: :created
+      render  status: :created,
+              json: @vacation_request
     else
-      render  json: { errors: @vacation_request.errors },
-              status: :unprocessable_entity
+      render  status: :unprocessable_entity,
+              json: { errors: @vacation_request.errors }
     end
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,9 +32,7 @@
               %li
                 = link_to "Teams",          '/#/teams'
               %li
-                = link_to "New Vacation",   '/#/new_vacation_request'
-              %li
-                = link_to "Vacations",      '/#/vacation_requests_list'
+                = link_to "Vacations",      '/#/vacation_requests'
               %li
                 = link_to "Holidays",       '/#/holidays'
               %li

--- a/spec/javascripts/views/vacation_request_form_spec.js
+++ b/spec/javascripts/views/vacation_request_form_spec.js
@@ -16,8 +16,8 @@ describe('VacationRequestForm view', function() {
       {'id':3,'kind':'unpaid','available_days':5.0,'user_id':1}
     ]);
 
-    setFixtures('<section></section>');
-    this.container = $('section');
+    setFixtures('<div class="new-vacation-request-form"></div>');
+    this.container = $('.new-vacation-request-form');
 
     this.view = new App.Views.VacationRequestForm({
       'holidays': this.holidays,
@@ -44,9 +44,9 @@ describe('VacationRequestForm view', function() {
 
   describe('.updateAvailableDaysInBadges()', function() {
     beforeEach(function() {
-      this.badgePlanned = this.container.find('.badge.planned');
-      this.badgeSickness = this.container.find('.badge.sickness');
-      this.badgeUnpaid = this.container.find('.badge.unpaid');
+      this.badgePlanned   = this.view.$('.badge.planned');
+      this.badgeSickness  = this.view.$('.badge.sickness');
+      this.badgeUnpaid    = this.view.$('.badge.unpaid');
 
       this.badgePlanned.text('');
       this.badgeSickness.text('');
@@ -55,7 +55,8 @@ describe('VacationRequestForm view', function() {
 
     it('sets all the radio button group badges with up-to-date information', function() {
       var newText = '';
-      expect(this.container.find('.badge').length).toEqual(3);
+      console.log(this.view);
+      expect(this.view.$('.badge').length).toEqual(3);
 
       expect(this.badgePlanned).toHaveText('');
       expect(this.badgeSickness).toHaveText('');
@@ -74,7 +75,7 @@ describe('VacationRequestForm view', function() {
 
   describe('.updateRequestButtonState()', function() {
     beforeEach(function() {
-      this.button = this.container.find('button[name=request]');
+      this.button = this.view.$('button[name=request]');
     });
 
     describe('with vacation duration greater than available days in selected vacation type', function() {
@@ -122,9 +123,9 @@ describe('VacationRequestForm view', function() {
 
   describe('responds to jQuery event', function() {
     it('click button[name=clear]', function() {
-      var htmlElement = this.container.find('button[name=clear]'),
-          inputFrom = this.container.find('input[name=from]'),
-          inputTo = this.container.find('input[name=to]');
+      var htmlElement = this.view.$('button[name=clear]'),
+          inputFrom = this.view.$('input[name=from]'),
+          inputTo = this.view.$('input[name=to]');
 
       inputFrom.val('2015-01-01');
       inputTo.val('2015-01-05');
@@ -141,7 +142,7 @@ describe('VacationRequestForm view', function() {
     });
 
     it('change input[name=from]', function() {
-      var htmlElement = this.container.find('input[name=from]'),
+      var htmlElement = this.view.$('input[name=from]'),
           oldValue = this.view.model.get('start_date'),
           newValue = '2015-01-01';
 
@@ -157,7 +158,7 @@ describe('VacationRequestForm view', function() {
     });
 
     it('click button[name=request]', function() {
-      var htmlElement = this.container.find('button[name=request]');
+      var htmlElement = this.view.$('button[name=request]');
       spyOn(this.view, 'onRequest');
       this.view.delegateEvents();
 
@@ -166,7 +167,7 @@ describe('VacationRequestForm view', function() {
     });
 
     it('change input[name=to]', function() {
-      var htmlElement = this.container.find('input[name=to]'),
+      var htmlElement = this.view.$('input[name=to]'),
           oldValue = this.view.model.get('planned_end_date'),
           newValue = '2015-01-01';
 
@@ -180,7 +181,7 @@ describe('VacationRequestForm view', function() {
     });
 
     it('change input:radio[name=vacation-type]', function() {
-      var htmlElement = this.container.find('input:radio[name=vacation-type]'),
+      var htmlElement = this.view.$('input:radio[name=vacation-type]'),
           oldValue = this.view.model.get('kind'),
           newValue = 'unpaid';
 
@@ -199,18 +200,13 @@ describe('VacationRequestForm view', function() {
 
   describe('produces correct HTML', function() {
     beforeEach(function() {
-      this.formContainer = this.container.find('.new-vacation-request');
-      this.datePickerContainer = this.container.find('.input-daterange');
-      this.toggleButtonWrapper = this.container.find('.btn.btn-default');
+      this.datePickerContainer = this.view.$('.input-daterange');
+      this.toggleButtonWrapper = this.view.$('.btn.btn-default');
       this.toggleButtonPlanned = this.toggleButtonWrapper.find('input:radio[name=vacation-type][value="planned"]');
     });
 
-    it('.new-vacation-request', function() {
-      expect(this.container).toContainElement(this.formContainer);
-    });
-
     it('.btn.btn-default', function() {
-      expect(this.formContainer).toContainElement(this.toggleButtonWrapper);
+      expect(this.view.el).toContainElement(this.toggleButtonWrapper);
       expect('.btn.btn-default > input').toHaveLength(3);
       expect('.btn.btn-default > .badge').toHaveLength(3);
     });
@@ -221,7 +217,6 @@ describe('VacationRequestForm view', function() {
       var days = this.availableVacations.models[0].attributes.available_days;
       expect(this.toggleButtonWrapper.selector+' .badge.planned').toHaveText('1|'+days.toString());
       expect(this.toggleButtonWrapper[0]).toContainText('planned');
-      // this.availableVacations
     });
 
     it('input:radio[name=vacation-type][value="sickness"]', function() {
@@ -248,10 +243,10 @@ describe('VacationRequestForm view', function() {
     });
 
     it('button[name=clear]', function() {
-      expect(this.formContainer).toContainElement('button[name=clear]');
+      expect(this.view.el).toContainElement('button[name=clear]');
     });
     it('button[name=request]', function() {
-      expect(this.formContainer).toContainElement('button[name=request]');
+      expect(this.view.el).toContainElement('button[name=request]');
     });
   });
 });


### PR DESCRIPTION
The view aggregates two existing views, VacationRequestForm and
VacationRequestsList. As a result these views lose their own pages
and render themselves in one place.
As an intermediator, the view passes collections to the views it uses.
The VacationRequestForm view interacts with the VacationRequestsList
with the 'sync' event on VacationRequests collection. When new vacation
request is created on the server, VacationRequestForm view uses fetch()
method on the collection. The VacationRequestsList view listens
to the 'sync' event on the collection and redraws the list
of vacation requests.

Remove redundant entities from HTML layout

Remove redundant entities from BB router

Update BB VacationRequest model
The model now accepts 'created_at' and 'updated_at' from server.

Update BB VacationRequestForm view
The view renders itself to new DOM element, according to layout of
the VacationRequests view.
The following components are updated in scope of these changes:
  - template for the view.

Update BB VacationRequestsList view
The view renders itself to new DOM element, according to layout of
the VacationRequests view.
The following components are updated in scope of these changes:
  - template for the view,
  - tests for the view.

Update VacationRequestsController
It seems that jQuery ajax() method expects proper response body
in answer. Otherwise it throws 'parseerror'.
The controller responds with proper status and with created record
in message.

@alazarchuk , @epmlys , @rubycop 