### PR TITLE
Add ApprovalRequestsController#accept action method

### DIFF
--- a/app/controllers/approval_requests_controller.rb
+++ b/app/controllers/approval_requests_controller.rb
@@ -13,6 +13,8 @@ class ApprovalRequestsController < ApplicationController
   before_action :set_approval_request, only: [:accept, :decline]
   before_action :check_vacation_request_status, only: [:accept, :decline]
 
+  after_action :verify_authorized, except: :index
+
   rescue_from ActiveRecord::RecordNotFound do
     head status: :not_found
   end
@@ -37,7 +39,7 @@ class ApprovalRequestsController < ApplicationController
   end
 
   def decline
-    # authorize @approval_request
+    authorize @approval_request
     status = VacationRequest.statuses[:declined]
     change_vacation_request_status(status)
     @approval_request.vacation_request.approval_requests.destroy_all
@@ -53,8 +55,7 @@ private
   def change_vacation_request_status(status)
     vacation_request = @approval_request.vacation_request
     vacation_request.status = status
-    vacation_request.save
-    vacation_request.errors
+    vacation_request.save!
   end
 
   def check_vacation_request_status

--- a/app/controllers/approval_requests_controller.rb
+++ b/app/controllers/approval_requests_controller.rb
@@ -1,8 +1,68 @@
+# Normally, each vacation request has approval request assigned to a manager.
+# When approval request is accepted, it is deleted from DB.
+# When vacation request has no approval requests, it changes its status
+# from 'requested' to 'accepted'.
+# Approval request can be declined. In this case all the approval requests
+# are deleted from DB, and status of the associated vacation request
+# is set to 'declined'.
+# Only managers are authorized to operate on approval requests.
+require 'errors/conflict_error'
+
 class ApprovalRequestsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_approval_request, only: [:accept, :decline]
+  before_action :check_vacation_request_status, only: [:accept, :decline]
+
+  rescue_from ActiveRecord::RecordNotFound do
+    head status: :not_found
+  end
+
+  rescue_from Errors::ConflictError do
+    head status: :conflict
+  end
+
   def index
     vacation_requests_ids = current_user.approval_requests
                             .pluck(:vacation_request_id).uniq
     requests = VacationRequest.find vacation_requests_ids
     render json: requests
+  end
+
+  def accept
+    authorize @approval_request
+    status = VacationRequest.statuses[:accepted]
+    change_vacation_request_status(status) if approval_request_count == 1
+    @approval_request.destroy
+    head status: :ok
+  end
+
+  def decline
+    # authorize @approval_request
+    status = VacationRequest.statuses[:declined]
+    change_vacation_request_status(status)
+    @approval_request.vacation_request.approval_requests.destroy_all
+    head status: :ok
+  end
+
+private
+
+  def approval_request_count
+    @approval_request.vacation_request.approval_requests.count
+  end
+
+  def change_vacation_request_status(status)
+    vacation_request = @approval_request.vacation_request
+    vacation_request.status = status
+    vacation_request.save
+    vacation_request.errors
+  end
+
+  def check_vacation_request_status
+    status = @approval_request.vacation_request.status
+    fail Errors::ConflictError if status != 'requested'
+  end
+
+  def set_approval_request
+    @approval_request = ApprovalRequest.find_by!(id: params[:id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,10 @@ class User < ActiveRecord::Base
     team_roles.managers.where(team: team).exists?
   end
 
+  def manager_of_user?(user)
+    user.list_of_assigned_managers_ids.include? id
+  end
+
   def manager?
     team_roles.managers.exists?
   end

--- a/app/models/vacation_request.rb
+++ b/app/models/vacation_request.rb
@@ -66,6 +66,6 @@ private
       .or(table[:actual_end_date].between(start_date..actual_end_date))
       .or(table[:start_date].lteq(start_date)
         .and(table[:actual_end_date].gteq(actual_end_date)))
-    ).where(user_id: user_id).count
+    ).where(user_id: user_id).where.not(id: id).count
   end
 end

--- a/app/policies/approval_request_policy.rb
+++ b/app/policies/approval_request_policy.rb
@@ -1,0 +1,17 @@
+# Only users with manager role can accept or decline approval requests, which
+# were assigned to them after vacation request creation by a team-mate.
+class ApprovalRequestPolicy < ApplicationPolicy
+  def index?
+    user
+  end
+
+  def accept?
+    user.manager_of_user?(record.vacation_request.user) &&
+      user.approval_requests.ids.include?(record.id)
+  end
+
+  def decline?
+    user.manager_of_user?(record.vacation_request.user) &&
+      user.approval_requests.ids.include?(record.id)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,10 @@ Rails.application.routes.draw do
 
   resources :approval_requests,
             only: [:index],
-            defaults: { format: :json }
+            defaults: { format: :json } do
+    member do
+      get 'accept'
+      get 'decline'
+    end
+  end
 end

--- a/lib/errors/conflict_error.rb
+++ b/lib/errors/conflict_error.rb
@@ -1,0 +1,3 @@
+module Errors
+  class ConflictError < StandardError; end
+end

--- a/spec/controllers/approval_requests_controller_spec.rb
+++ b/spec/controllers/approval_requests_controller_spec.rb
@@ -1,0 +1,346 @@
+require 'rails_helper'
+
+RSpec.describe ApprovalRequestsController do
+  let(:team) { create :team, :with_users, number_of_members: 1 }
+  let(:manager) { team.team_roles.managers.first.user }
+  let(:member)  { team.team_roles.members.first.user }
+  let(:guest)   { team.team_roles.guests.first.user }
+  let(:user)    { manager }
+  let(:approval_request) { manager.approval_requests.first }
+  let(:create_vacation_request) do
+    create :vacation_request, :with_approval_requests, user: member
+  end
+
+  before { create_vacation_request }
+
+  RSpec.shared_examples 'request with conflict' do
+    it 'should respond with status code :conflict (409)' do
+      send_request
+      expect(response).to have_http_status(:conflict)
+    end
+
+    it 'should not remove approval request from DB' do
+      expect { send_request }.not_to change(ApprovalRequest, :count)
+    end
+
+    it 'should not change vacation request status' do
+      id = approval_request.vacation_request_id
+
+      expect { send_request }
+        .not_to change { VacationRequest.find_by(id: id).status }
+    end
+  end
+
+  ################################################################## GET #accept
+  describe 'GET #accept' do
+    let(:send_request) { get :accept, params }
+    let(:params) { Hash[format: :json, id: approval_request.id] }
+
+    context 'from authenticated user with manager role' do
+      before { sign_in user }
+
+      context 'with ID of not existing approval request' do
+        let(:params) { Hash[format: :json, id: (approval_request.id - 1)] }
+
+        it 'should respond with status code :not_found (404)' do
+          send_request
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'should not remove approval request from DB' do
+          expect { send_request }.not_to change(ApprovalRequest, :count)
+        end
+
+        it 'should not change vacation request status' do
+          id = approval_request.vacation_request_id
+
+          expect { send_request }
+            .not_to change { VacationRequest.find_by(id: id).status }
+        end
+      end
+
+      context 'when vacation request status is set to "accepted"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:accepted]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "declined"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:declined]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "cancelled"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:cancelled]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "inprogress"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:inprogress]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "used"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:used]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'without another user with manager role in the team' do
+        it 'should respond with status code :ok (200)' do
+          send_request
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'should remove approval request from DB' do
+          expect { send_request }.to change(ApprovalRequest, :count).by(-1)
+        end
+
+        it 'should set vacation request status to "accepted"' do
+          id = approval_request.vacation_request_id
+
+          expect { send_request }
+            .to change { VacationRequest.find_by(id: id).status }
+            .from('requested').to('accepted')
+        end
+      end
+
+      context 'with another user with manager role in the team' do
+        let(:team) do
+          create :team, :with_users, number_of_members: 1, number_of_managers: 2
+        end
+
+        context 'who has not yet responded to the approval request' do
+          it 'should respond with status code :ok (200)' do
+            send_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'should remove approval request from DB' do
+            expect { send_request }.to change(ApprovalRequest, :count).by(-1)
+          end
+
+          it 'should not change vacation request status' do
+            id = approval_request.vacation_request_id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+        end
+
+        context 'who has already accepted the approval request' do
+          let(:another_manager) { team.team_roles.managers.second.user }
+
+          before do
+            another_manager.approval_requests.first.destroy
+          end
+
+          it 'should respond with status code :ok (200)' do
+            send_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'should remove approval request from DB' do
+            expect { send_request }.to change(ApprovalRequest, :count).by(-1)
+          end
+
+          it 'should set vacation request status to "accepted"' do
+            id = approval_request.vacation_request_id
+
+            expect { send_request }
+              .to change { VacationRequest.find_by(id: id).status }
+              .from('requested').to('accepted')
+          end
+        end
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthorized request'
+
+      it 'should not delete approval request from DB' do
+        expect { send_request }.not_to change(ApprovalRequest, :count)
+      end
+    end
+  end
+
+  ################################################################# GET #decline
+  describe 'GET #decline' do
+    let(:send_request) { get :decline, params }
+    let(:params) { Hash[format: :json, id: approval_request.id] }
+
+    context 'from authenticated user with manager role' do
+      before { sign_in user }
+
+      context 'with ID of not existing approval request' do
+        let(:params) { Hash[format: :json, id: (approval_request.id - 1)] }
+
+        it 'should respond with status code :not_found (404)' do
+          send_request
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it 'should not remove approval request from DB' do
+          expect { send_request }.not_to change(ApprovalRequest, :count)
+        end
+
+        it 'should not change vacation request status' do
+          id = approval_request.vacation_request_id
+
+          expect { send_request }
+            .not_to change { VacationRequest.find_by(id: id).status }
+        end
+      end
+
+      context 'when vacation request status is set to "accepted"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:accepted]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "declined"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:declined]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "cancelled"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:cancelled]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "inprogress"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:inprogress]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "used"' do
+        before do
+          vacation_request = approval_request.vacation_request
+          vacation_request.status = VacationRequest.statuses[:used]
+          vacation_request.save
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'without another user with manager role in the team' do
+        it 'should respond with status code :ok (200)' do
+          send_request
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'should remove approval request from DB' do
+          expect { send_request }.to change(ApprovalRequest, :count).by(-1)
+        end
+
+        it 'should set vacation request status to "declined"' do
+          id = approval_request.vacation_request_id
+
+          expect { send_request }
+            .to change { VacationRequest.find_by(id: id).status }
+            .from('requested').to('declined')
+        end
+      end
+
+      context 'with another user with manager role in the team' do
+        let(:team) do
+          create :team, :with_users, number_of_members: 1, number_of_managers: 2
+        end
+
+        context 'who has not yet responded to the approval request' do
+          it 'should respond with status code :ok (200)' do
+            send_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'should remove all associated approval requests from DB' do
+            expect { send_request }.to change(ApprovalRequest, :count).by(-2)
+          end
+
+          it 'should set vacation request status to "declined"' do
+            id = approval_request.vacation_request_id
+
+            expect { send_request }
+              .to change { VacationRequest.find_by(id: id).status }
+              .from('requested').to('declined')
+          end
+        end
+
+        context 'who has already accepted the approval request' do
+          let(:another_manager) { team.team_roles.managers.second.user }
+
+          before do
+            another_manager.approval_requests.first.destroy
+          end
+
+          it 'should respond with status code :ok (200)' do
+            send_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'should remove approval request from DB' do
+            expect { send_request }.to change(ApprovalRequest, :count).by(-1)
+          end
+
+          it 'should set vacation request status to "declined"' do
+            id = approval_request.vacation_request_id
+
+            expect { send_request }
+              .to change { VacationRequest.find_by(id: id).status }
+              .from('requested').to('declined')
+          end
+        end
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthorized request'
+
+      it 'should not delete approval request from DB' do
+        expect { send_request }.not_to change(ApprovalRequest, :count)
+      end
+    end
+  end
+end

--- a/spec/factories/vacation_requests.rb
+++ b/spec/factories/vacation_requests.rb
@@ -40,5 +40,15 @@ FactoryGirl.define do
     trait :used do
       status 'used'
     end
+
+    trait :with_approval_requests do
+      after :create do |vacation_request|
+        user = User.find_by id: vacation_request.user_id
+        user.list_of_assigned_managers_ids.each do |manager_id|
+          ApprovalRequest.create(vacation_request_id: vacation_request.id,
+                                 manager_id: manager_id)
+        end
+      end
+    end
   end
 end

--- a/spec/policies/approval_request_policy_spec.rb
+++ b/spec/policies/approval_request_policy_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+describe ApprovalRequestPolicy do
+  let(:team) do
+    create :team, :with_users, number_of_members: 1, number_of_managers: 2
+  end
+
+  let(:second_manager) { team.team_roles.managers.second.user }
+  let(:manager) { team.team_roles.managers.first.user }
+  let(:member)  { team.team_roles.members.first.user }
+  let(:guest)   { team.team_roles.guests.first.user }
+  let(:approval_request) { manager.approval_requests.first }
+  let(:not_own_approval_request) do
+    second_manager.approval_requests.first
+  end
+
+  let(:create_vacation_request) do
+    create :vacation_request, :with_approval_requests, user: member
+  end
+
+  before { create_vacation_request }
+
+  subject { ApprovalRequestPolicy }
+
+  permissions :accept?, :decline? do
+    context 'for a team-mate user' do
+      context 'with role=manager' do
+        context 'who owns the approval request' do
+          it 'grants access' do
+            expect(subject).to permit(manager, approval_request)
+          end
+        end
+
+        context 'who does not own the approval request' do
+          it 'denies access' do
+            expect(subject).not_to permit(manager, not_own_approval_request)
+          end
+        end
+      end
+
+      context 'with role=member' do
+        it 'denies access' do
+          expect(subject).not_to permit(member, approval_request)
+        end
+      end
+
+      context 'with role=guest' do
+        it 'denies access' do
+          expect(subject).not_to permit(guest, approval_request)
+        end
+      end
+    end
+
+    context 'for not a team-mate user' do
+      let(:another_team) do
+        create :team, :with_users, number_of_members: 1
+      end
+      let(:approval_request) do
+        ApprovalRequest.create vacation_request_id: create_vacation_request.id,
+                               manager_id: another_manager.id
+      end
+      let(:another_manager) { another_team.team_roles.managers.first.user }
+      let(:another_member)  { another_team.team_roles.members.first.user }
+      let(:another_guest)   { another_team.team_roles.guests.first.user }
+
+      context 'with role=manager' do
+        context 'who owns the approval request' do
+          it 'denies access' do
+            expect(subject).not_to permit(another_manager, approval_request)
+          end
+        end
+
+        context 'who does not own the approval request' do
+          it 'denies access' do
+            expect(subject)
+              .not_to permit(another_manager, not_own_approval_request)
+          end
+        end
+      end
+
+      context 'with role=member' do
+        it 'denies access' do
+          expect(subject).not_to permit(another_member, approval_request)
+        end
+      end
+
+      context 'with role=guest' do
+        it 'denies access' do
+          expect(subject).not_to permit(another_guest, approval_request)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/unauthenticated_request.rb
+++ b/spec/support/shared_examples/unauthenticated_request.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples 'unauthenticated request' do
+  before { send_request }
+
+  it { expect(response).to have_http_status(:unauthorized) }
+
+  it 'should contain error message as JSON data in response body' do
+    expect(response.body).to have_json_attribute(:error)
+      .with_value('You need to sign in or sign up before continuing.')
+  end
+end

--- a/spec/support/shared_examples/unauthorized_request.rb
+++ b/spec/support/shared_examples/unauthorized_request.rb
@@ -1,10 +1,5 @@
 RSpec.shared_examples 'unauthorized request' do
   before { send_request }
 
-  it { expect(response).to have_http_status(:unauthorized) }
-
-  it 'should contain error message as JSON data in response body' do
-    expect(response.body).to have_json_attribute(:error)
-      .with_value('You need to sign in or sign up before continuing.')
-  end
+  it { expect(response).to have_http_status(:forbidden) }
 end


### PR DESCRIPTION
Update RoR router
The following action methods are members of :approval_requests
resources:
  - accept,
  - decline.

Update :vacation_request factory
Add :with_approval_requests trait that creates approval requests
assigned to team managers.

Add tests for ApprovalRequestsController
The following action methods are tested:
  - accept,
  - decline.

Add authorization policy for ApprovalRequest

Add custom error ConflictError
This error is used to implement handy handling of conflicts in
VacationRequest model state.

Update User model
The model provides #manager_of_user?(user) method to verify if the user
is a manager for another user.

Fix custom validation in VacationRequest model
It was not possible to save existing model because of false positive
validation issue.
Now cannot_intersect_with_other_vacations() considers the fact that it
may be used for an existing record and checks the ID of the record.

@alazarchuk , @epmlys , @rubycop, @afurm 