### PR TITLE
Fix shared exaples bad naming

### DIFF
--- a/spec/controllers/holidays_controller_spec.rb
+++ b/spec/controllers/holidays_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe HolidaysController do
     context 'from unauthenticated user' do
       before { send_request }
 
-      it_should_behave_like 'unauthorized request'
+      it_should_behave_like 'unauthenticated request'
     end
   end
 
@@ -80,7 +80,7 @@ RSpec.describe HolidaysController do
 
     context 'from unauthenticated user' do
       context 'with correct data' do
-        it_should_behave_like 'unauthorized request'
+        it_should_behave_like 'unauthenticated request'
 
         it 'should not add any record to DB' do
           expect { send_request }.not_to change(Holiday, :count)
@@ -150,7 +150,7 @@ RSpec.describe HolidaysController do
       context 'with correct data' do
         before { send_request }
 
-        it_should_behave_like 'unauthorized request'
+        it_should_behave_like 'unauthenticated request'
 
         it 'should not update specified record in DB' do
           expect(Holiday.find_by(id: holiday.id).description)
@@ -197,7 +197,7 @@ RSpec.describe HolidaysController do
         send_request
       end
 
-      it_should_behave_like 'unauthorized request'
+      it_should_behave_like 'unauthenticated request'
 
       it 'should not delete specified record' do
         expect(Holiday.find_by(id: holiday.id)).not_to be_nil

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TeamsController do
     context 'from unauthenticated user' do
       before { send_request }
 
-      it_should_behave_like 'unauthorized request'
+      it_should_behave_like 'unauthenticated request'
     end
   end
 
@@ -82,7 +82,7 @@ RSpec.describe TeamsController do
       context 'with correct data' do
         let(:team) { FactoryGirl.build(:team, name: 'Superheros') }
 
-        it_should_behave_like 'unauthorized request'
+        it_should_behave_like 'unauthenticated request'
 
         it 'should not add any record to DB' do
           expect { send_request }.not_to change(Team, :count)
@@ -164,7 +164,7 @@ RSpec.describe TeamsController do
 
         before { send_request }
 
-        it_should_behave_like 'unauthorized request'
+        it_should_behave_like 'unauthenticated request'
 
         it 'should not update specified record in DB' do
           expect(Team.find_by(id: team.id).name).to eq(team.name)
@@ -246,7 +246,7 @@ RSpec.describe TeamsController do
 
         before { send_request }
 
-        it_should_behave_like 'unauthorized request'
+        it_should_behave_like 'unauthenticated request'
 
         it 'should not update specified record in DB' do
           expect(Team.find_by(id: team.id).name).to eq(team.name)
@@ -293,7 +293,7 @@ RSpec.describe TeamsController do
         delete :destroy, params
       end
 
-      it_should_behave_like 'unauthorized request'
+      it_should_behave_like 'unauthenticated request'
 
       it 'should not delete specified record' do
         expect(Team.find_by(id: teams.first.id)).not_to be_nil
@@ -337,7 +337,7 @@ RSpec.describe TeamsController do
     end
 
     context 'from unauthenticated user' do
-      it_should_behave_like 'unauthorized request'
+      it_should_behave_like 'unauthenticated request'
     end
   end
 
@@ -374,7 +374,7 @@ RSpec.describe TeamsController do
     end
 
     context 'from unauthenticated user' do
-      it_should_behave_like 'unauthorized request'
+      it_should_behave_like 'unauthenticated request'
     end
   end
 end

--- a/spec/controllers/vacation_requests_controller_spec.rb
+++ b/spec/controllers/vacation_requests_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe VacationRequestsController do
 
     context 'from unauthenticated user' do
       context 'with correct data' do
-        it_should_behave_like 'unauthorized request'
+        it_should_behave_like 'unauthenticated request'
 
         it 'should not add any record to DB' do
           expect { send_request }.not_to change(VacationRequest, :count)


### PR DESCRIPTION
Rename `unauthorized` into `unauthenticated`, and create `unauthorized`.
Previous commit introduces changes in shared examples naming, along with
new shared examples.
Originally, the `unauthorized` was chosen after status code 401 naming.
When another shared example was introduced to represent authorization
issue it appeared that shared examples' names should represent their
true meaning.
As a result, shared examples in subject must be treated as follows:
  * `unauthenticated` -- user must pass login/password check,
    that is, to log into system;
  * `unauthorized`    -- user must have appropriate privileges along
    with logging into system.

@alazarchuk , @epmlys , @rubycop , @afurm