### PR TITLE
Add VacationRequestsController#cancel action method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,10 @@ class User < ActiveRecord::Base
   has_many  :available_vacations, dependent: :destroy
   has_many  :approval_requests, foreign_key: :manager_id, dependent: :destroy
 
+  def owns_vacation_request?(vacation_request)
+    vacation_requests.ids.include? vacation_request.id
+  end
+
   def manager_of?(team)
     team_roles.managers.where(team: team).exists?
   end

--- a/app/policies/vacation_request_policy.rb
+++ b/app/policies/vacation_request_policy.rb
@@ -11,7 +11,7 @@ class VacationRequestPolicy < ApplicationPolicy
     user.manager? || user.member?
   end
 
-  def destroy?
-    user.manager? || user.member?
+  def cancel?
+    (user.manager? || user.member?) && user.owns_vacation_request?(record)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,11 @@ Rails.application.routes.draw do
 
   resources :vacation_requests,
             only: [:index, :show, :create, :update],
-            defaults: { format: :json }
+            defaults: { format: :json } do
+    member do
+      get 'cancel'
+    end
+  end
 
   resources :approval_requests,
             only: [:index],

--- a/spec/controllers/vacation_requests_controller_spec.rb
+++ b/spec/controllers/vacation_requests_controller_spec.rb
@@ -1,16 +1,41 @@
 require 'rails_helper'
 
+RSpec.shared_examples 'request with conflict' do
+  it 'should respond with status code :conflict (409)' do
+    send_request
+    expect(response).to have_http_status(:conflict)
+  end
+
+  it 'should not change vacation request status' do
+    expect { send_request }
+      .not_to change { VacationRequest.find_by(id: vacation_request.id).status }
+  end
+end
+
+RSpec.shared_examples 'pretty request' do
+  it 'should respond with status code :ok (200)' do
+    send_request
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'should set vacation request status to "cancelled"' do
+    expect { send_request }
+      .to change { VacationRequest.find_by(id: vacation_request.id).status }
+      .to('cancelled')
+  end
+end
+
 RSpec.describe VacationRequestsController do
   let(:team) { create :team, :with_users, number_of_members: 1 }
   let(:manager) { team.team_roles.managers.first.user }
   let(:member)  { team.team_roles.members.first.user }
   let(:guest)   { team.team_roles.guests.first.user }
   let(:user)    { manager }
-  let(:vacation_request) { create(:vacation_request) }
+  let(:vacation_request) { create(:vacation_request, user: user) }
 
   ################################################################# POST #create
   describe 'POST #create' do
-    let(:send_request)  { post :create, params }
+    let(:send_request) { post :create, params }
     let(:params) { Hash[format: :json, vacation_request: json_data] }
     let(:json_data) { YAML.load(vacation_request.to_json) }
     let(:vacation_request) { build(:vacation_request) }
@@ -160,6 +185,181 @@ RSpec.describe VacationRequestsController do
         it 'should not add any record to DB' do
           expect { send_request }.not_to change(VacationRequest, :count)
         end
+      end
+    end
+  end
+
+  ################################################################## GET #cancel
+  describe 'GET #cancel' do
+    let(:team) do
+      create :team, :with_users, number_of_managers: 2, number_of_members: 1
+    end
+    let(:send_request) { get :cancel, params }
+    let(:params) { Hash[format: :json, id: vacation_request.id] }
+
+    context 'from authenticated user' do
+      before { sign_in user }
+
+      context 'with ID of not existing vacation request' do
+        let(:params) { Hash[format: :json, id: (vacation_request.id - 1)] }
+
+        it 'should respond with status code :not_found (404)' do
+          send_request
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context 'with manager role' do
+        context 'who owns the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: user)
+          end
+
+          context 'when vacation request status is set to "requested"' do
+            it 'should delete all associated approval requests' do
+              expect { send_request }
+                .to change { vacation_request.approval_requests.count }
+                .from(1).to(0)
+            end
+
+            it_should_behave_like 'pretty request'
+          end
+
+          context 'when vacation request status is set to "accepted"' do
+            let(:vacation_request) do
+              create(:vacation_request, user: user, status: 'accepted')
+            end
+
+            it_should_behave_like 'pretty request'
+          end
+        end
+
+        context 'who does not own the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: member)
+          end
+
+          it 'should not change vacation request status' do
+            id = vacation_request.id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+
+          it 'should not delete associated approval requests' do
+            expect { send_request }
+              .not_to change { vacation_request.approval_requests.count }
+          end
+
+          it_should_behave_like 'unauthorized request'
+        end
+      end
+
+      context 'with member role' do
+        let(:user) { member }
+        context 'who owns the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: user)
+          end
+
+          context 'when vacation request status is set to "requested"' do
+            it 'should delete all associated approval requests' do
+              expect { send_request }
+                .to change { vacation_request.approval_requests.count }
+                .from(2).to(0)
+            end
+
+            it_should_behave_like 'pretty request'
+          end
+
+          context 'when vacation request status is set to "accepted"' do
+            let(:vacation_request) do
+              create(:vacation_request, user: user, status: 'accepted')
+            end
+
+            it_should_behave_like 'pretty request'
+          end
+        end
+
+        context 'who does not own the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: manager)
+          end
+
+          it 'should not change vacation request status' do
+            id = vacation_request.id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+
+          it 'should not delete associated approval requests' do
+            expect { send_request }
+              .not_to change { vacation_request.approval_requests.count }
+          end
+
+          it_should_behave_like 'unauthorized request'
+        end
+      end
+
+      context 'with guest role' do
+        let(:user) { guest }
+        context 'who owns the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: user)
+          end
+
+          it 'should not change vacation request status' do
+            id = vacation_request.id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+
+          it_should_behave_like 'unauthorized request'
+        end
+      end
+
+      context 'when vacation request status is set to "declined"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'declined')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "cancelled"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'cancelled')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "inprogress"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'inprogress')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "used"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'used')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthenticated request'
+
+      it 'should not change vacation request status' do
+        id = vacation_request.id
+        expect { send_request }
+          .not_to change { VacationRequest.find_by(id: id).status }
       end
     end
   end

--- a/spec/policies/vacation_request_policy_spec.rb
+++ b/spec/policies/vacation_request_policy_spec.rb
@@ -9,7 +9,7 @@ describe VacationRequestPolicy do
 
   subject { VacationRequestPolicy }
 
-  permissions :create?, :update?, :destroy? do
+  permissions :create?, :update? do
     context 'for user of any team' do
       context 'with role=manager' do
         it 'grants access' do
@@ -24,6 +24,62 @@ describe VacationRequestPolicy do
       context 'with role=guest' do
         it 'denies access' do
           expect(subject).not_to permit(guest, vacation_request)
+        end
+      end
+    end
+  end
+
+  permissions :cancel? do
+    context 'for user with manager role' do
+      let(:user) { manager }
+
+      context 'who does not own the vacation request' do
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+
+      context 'who owns the vacation request' do
+        let(:vacation_request) { create(:vacation_request, user: user) }
+
+        it 'grants access' do
+          expect(subject).to permit(user, vacation_request)
+        end
+      end
+    end
+
+    context 'for user with member role' do
+      let(:user) { member }
+
+      context 'who does not own the vacation request' do
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+
+      context 'who owns the vacation request' do
+        let(:vacation_request) { create(:vacation_request, user: user) }
+
+        it 'grants access' do
+          expect(subject).to permit(user, vacation_request)
+        end
+      end
+    end
+
+    context 'for user with guest role' do
+      let(:user) { guest }
+
+      context 'who does not own the vacation request' do
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+
+      context 'who owns the vacation request' do
+        let(:vacation_request) { create(:vacation_request, user: user) }
+
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
         end
       end
     end


### PR DESCRIPTION
Update routes with new action method
Add the method as a member of `:vacation_requests` resources.

Update VacationRequestsController
Add support for checking of the vacation request status and responders
for `ActiveRecord::RecordNotFound` and custom `Errors::ConflictError`
exceptions.

Update VacationRequest authorization policy

Cover all the new functionality with tests

@alazarchuk , @epmlys , @rubycop , @afurm