### PR TITLE
Improve RoR VacationRequest model validation

### DIFF
--- a/app/models/vacation_request.rb
+++ b/app/models/vacation_request.rb
@@ -38,7 +38,7 @@ class VacationRequest < ActiveRecord::Base
   ]
 
   def cannot_intersect_with_other_vacations
-    number_of_records  = number_of_intersected_records
+    number_of_records = number_of_intersected_records
 
     errors.add(:base, 'cannot intersect with other vacations')\
       if number_of_records > 0
@@ -66,6 +66,12 @@ private
       .or(table[:actual_end_date].between(start_date..actual_end_date))
       .or(table[:start_date].lteq(start_date)
         .and(table[:actual_end_date].gteq(actual_end_date)))
-    ).where(user_id: user_id).where.not(id: id).count
+    )
+      .where(user_id: user_id)
+      .where.not(id: id,
+                 status: [
+                   VacationRequest.statuses[:cancelled],
+                   VacationRequest.statuses[:declined]]
+                ).count
   end
 end

--- a/spec/models/vacation_request_spec.rb
+++ b/spec/models/vacation_request_spec.rb
@@ -179,6 +179,38 @@ RSpec.describe VacationRequest do
           expect(vacation_request).not_to be_valid
         end
       end
+
+      context 'with any kind of intersections' do
+        describe 'with status="cancelled"' do
+          before do
+            create(:vacation_request,
+                   user: user,
+                   start_date: '2015-08-30', planned_end_date: '2015-09-25',
+                   status: VacationRequest.statuses[:cancelled])
+            vacation_request.validate
+          end
+
+          it 'does not set any errors' do
+            expect(vacation_request.errors).to be_empty
+            expect(vacation_request).to be_valid
+          end
+        end
+
+        describe 'with status="declined"' do
+          before do
+            create(:vacation_request,
+                   user: user,
+                   start_date: '2015-08-30', planned_end_date: '2015-09-25',
+                   status: VacationRequest.statuses[:declined])
+            vacation_request.validate
+          end
+
+          it 'does not set any errors' do
+            expect(vacation_request.errors).to be_empty
+            expect(vacation_request).to be_valid
+          end
+        end
+      end
     end
 
     context 'when another user has vacation requests' do


### PR DESCRIPTION
The `VacationRequest#cannot_intersect_with_other_vacations` method
must exclude records with both `cancelled` and `declined` statuses.
As a result, any record that intersects with records with mentioned
above statuses, is valid one.
@alazarchuk , @epmlys , @rubycop , @afurm