### PR TITLE
Implement BB cancellation of vacation request

### DIFF
--- a/app/assets/javascripts/collections/personal_vacation_requests.js
+++ b/app/assets/javascripts/collections/personal_vacation_requests.js
@@ -1,0 +1,6 @@
+App.Collections.PersonalVacationRequests = Backbone.Collection.extend({
+  url: function() {
+    var userID = App.currentUser.get('id');
+    return '/users/' + userID.toString() + '/requested_vacations/';
+  }
+});

--- a/app/assets/javascripts/templates/approval_request_owner_operations.jst.hamljs
+++ b/app/assets/javascripts/templates/approval_request_owner_operations.jst.hamljs
@@ -1,0 +1,1 @@
+%button.btn.btn-danger{name:'cancel'} Cancel

--- a/app/assets/javascripts/templates/vacation_requests_table.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_requests_table.jst.hamljs
@@ -1,0 +1,1 @@
+%table.table.table-condensed

--- a/app/assets/javascripts/views/dashboard.js
+++ b/app/assets/javascripts/views/dashboard.js
@@ -7,6 +7,7 @@ App.Views.Dashboard = Backbone.View.extend({
   },
 
   initialize: function(options) {
+    this.options = options;
     this.holidays = options.holidays;
     this.teams = options.teams;
     this.teamID = 0;
@@ -31,25 +32,7 @@ App.Views.Dashboard = Backbone.View.extend({
   },
 
   renderPersonalRequests: function() {
-    var userID = App.currentUser.get('id');
-    var options = {
-      user_id:userID,
-      el:'.personal-requests .panel-body',
-      columns: [{
-          field: 'start_date',
-          title: 'Start date',
-          sortable: true
-      }, {
-          field: 'actual_end_date',
-          title: 'End date',
-          sortable: true
-      }, {
-          field: 'kind',
-          title: 'Type',
-          sortable: true
-      }],
-    };
-    this.personalRequests = new App.Views.ApprovalRequests(options);
+    this.personalRequests = new App.Views.PersonalVacationRequests(this.options);
   },
 
   renderPendingRequests: function() {
@@ -58,20 +41,25 @@ App.Views.Dashboard = Backbone.View.extend({
       columns: [{
           field: 'start_date',
           title: 'Start date',
+          valign: 'middle',
           sortable: true
       }, {
           field: 'actual_end_date',
           title: 'End date',
+          valign: 'middle',
           sortable: true
       }, {
           field: 'kind',
           title: 'Type',
+          align: 'center',
+          valign: 'middle',
           sortable: true
       }, {
           field: 'user_id',
           title: 'User ID',
+          align: 'center',
+          valign: 'middle',
           sortable: true
-
       }],
     };
     this.pendingRequests = new App.Views.ApprovalRequests(options);

--- a/app/assets/javascripts/views/personal_vacation_requests.js
+++ b/app/assets/javascripts/views/personal_vacation_requests.js
@@ -1,0 +1,91 @@
+App.Views.PersonalVacationRequests = Backbone.View.extend({
+  el: '.personal-requests .panel-body',
+  template: JST['templates/vacation_requests_table'],
+
+  operationsEvents: function() {
+    console.log(this);
+    return {
+      'click button[name=cancel]': this.onCancel
+    };
+  },
+
+  onCancel: function(event, value, row, index) {
+    var that = this;
+
+    $.get('vacation_requests/'+row.id.toString()+'/cancel')
+      .done(function() {
+        that.$table.bootstrapTable('remove', {field:'id', values: [row.id]});
+        // TODO: implement notification, if needed
+      })
+      .fail(function(response) {
+        // TODO: implement notification
+      });
+  },
+
+  initialize: function(options) {
+    this.options = options;
+    this.requests = new App.Collections.PersonalVacationRequests();
+
+    this.listenTo(this.requests, 'sync', this.render);
+
+    // TODO: extract into router
+    this.requests.fetch();
+
+    this.onCancel = _.bind(this.onCancel, this);
+  },
+
+  render: function() {
+    this.$el.html(this.template());
+
+    if (this.requests.isEmpty()) {
+      this.renderMessage();
+    } else {
+      this.renderRequests();
+    }
+    return this;
+  },
+
+  renderMessage: function() {
+    var message = 'No pending requests.',
+        html = '<p>' + message + '</p>';
+
+    this.$el.html(html);
+  },
+
+  renderRequests: function() {
+    this.$table = $(this.$el.selector + ' table');
+
+    this.$table.bootstrapTable({
+      data: this.requests.toJSON(),
+      columns: [{
+          field: 'start_date',
+          title: 'Start date',
+          valign: 'middle',
+          sortable: true
+      }, {
+          field: 'actual_end_date',
+          title: 'End date',
+          valign: 'middle',
+          sortable: true
+      }, {
+          field: 'kind',
+          title: 'Type',
+          align: 'center',
+          valign: 'middle',
+          sortable: true
+      }, {
+          field: 'operations',
+          title: 'Operations',
+          align: 'center',
+          events: this.operationsEvents(),
+          formatter: this.ownerOperationsFormatter,
+          width: '15%',
+          sortable: false
+      }],
+    });
+  },
+
+  ownerOperationsFormatter: function(value, row, index) {
+    return JST['templates/approval_request_owner_operations']();
+  }
+});


### PR DESCRIPTION
Add template for the operation button

Refactor handling of personal vacation requests
Extract related logic into separate view.

Add App.Collections.PersonalVacationRequests
The collection represents all vacation requests that are to be approved
by managers.

Add App.Views.PersonalVacationRequests
The view is responsible for rendering and interactive manipulations on
a list of vacations provided by PersonalVacationRequests collection.

Add template for vacation requests table
The template provides properly styled table container.

@alazarchuk , @epmlys , @rubycop , @afurm