### PR TITLE
Implement setting vacation to inprogress status

### DIFF
--- a/app/assets/javascripts/templates/vacation_operations/cancelled.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_operations/cancelled.jst.hamljs
@@ -1,0 +1,1 @@
+%button.btn.btn-danger{name:'cancel'} Cancel

--- a/app/assets/javascripts/templates/vacation_operations/inprogress.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_operations/inprogress.jst.hamljs
@@ -1,0 +1,1 @@
+%button.btn.btn-info{name:'start'} Start

--- a/app/assets/javascripts/views/vacation_requests_list.js
+++ b/app/assets/javascripts/views/vacation_requests_list.js
@@ -4,7 +4,8 @@ App.Views.VacationRequestsList = Backbone.View.extend({
 
   operationsEvents: function() {
     return {
-      'click button[name=cancel]': this.onCancel
+      'click button[name=cancel]':  this.onCancel,
+      'click button[name=start]':   this.onStart
     };
   },
 
@@ -14,6 +15,7 @@ App.Views.VacationRequestsList = Backbone.View.extend({
     this.listenTo(this.collection, 'sync',  this.renderTable);
 
     this.onCancel = _.bind(this.onCancel, this);
+    this.onStart  = _.bind(this.onStart, this);
   },
 
   render: function() {
@@ -80,11 +82,39 @@ App.Views.VacationRequestsList = Backbone.View.extend({
       });
   },
 
+  onStart: function(event, value, row, index) {
+    var that = this;
+
+    $.get('vacation_requests/'+row.id.toString()+'/start')
+      .done(function() {
+        // TODO: implement notification, if needed
+        // Trigger table update
+        console.log('DONE');
+        that.collection.fetch();
+      })
+      .fail(function(response) {
+        // TODO: implement notification
+        console.error('FAIL');
+        console.error(response.responseText);
+      });
+  },
+
   ownerOperationsFormatter: function(value, row, index) {
-    if (row.status === App.Vacation.statuses.cancelled) {
-      return '';
+    var buttons = [],
+        canBeCancelled = false,
+        canBeSetToInprogress = false;
+
+    canBeCancelled = (row.status !== App.Vacation.statuses.cancelled && row.status !== App.Vacation.statuses.inprogress);
+    canBeSetToInprogress = (row.status === App.Vacation.statuses.accepted);
+
+    if (canBeSetToInprogress) {
+      buttons.push(JST['templates/vacation_operations/inprogress']());
     }
 
-    return JST['templates/approval_request_owner_operations']();
+    if (canBeCancelled) {
+      buttons.push(JST['templates/vacation_operations/cancelled']());
+    }
+
+    return buttons.join('&nbsp;');
   }
 });

--- a/app/policies/vacation_request_policy.rb
+++ b/app/policies/vacation_request_policy.rb
@@ -4,14 +4,28 @@ class VacationRequestPolicy < ApplicationPolicy
   end
 
   def create?
-    user.manager? || user.member?
+    manager_or_member?
   end
 
   def update?
-    user.manager? || user.member?
+    manager_or_member?
   end
 
   def cancel?
+    manager_or_member_who_owns_vacation?
+  end
+
+  def start?
+    manager_or_member_who_owns_vacation?
+  end
+
+private
+
+  def manager_or_member?
+    (user.manager? || user.member?)
+  end
+
+  def manager_or_member_who_owns_vacation?
     (user.manager? || user.member?) && user.owns_vacation_request?(record)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
             defaults: { format: :json } do
     member do
       get 'cancel'
+      get 'start'
     end
   end
 

--- a/spec/controllers/vacation_requests_controller_spec.rb
+++ b/spec/controllers/vacation_requests_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe VacationRequestsController do
     end
   end
 
-  shared_examples 'pretty request' do
+  shared_examples 'pretty cancel request' do
     it 'should respond with status code :ok (200)' do
       send_request
       expect(response).to have_http_status(:ok)
@@ -31,6 +31,19 @@ RSpec.describe VacationRequestsController do
       expect { send_request }
         .to change { VacationRequest.find_by(id: vacation_request.id).status }
         .to('cancelled')
+    end
+  end
+
+  shared_examples 'pretty start request' do
+    it 'should respond with status code :ok (200)' do
+      send_request
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'should set vacation request status to "inprogress"' do
+      expect { send_request }
+        .to change { VacationRequest.find_by(id: vacation_request.id).status }
+        .to('inprogress')
     end
   end
 
@@ -220,7 +233,7 @@ RSpec.describe VacationRequestsController do
                 .from(1).to(0)
             end
 
-            it_should_behave_like 'pretty request'
+            it_should_behave_like 'pretty cancel request'
           end
 
           context 'when vacation request status is set to "accepted"' do
@@ -228,7 +241,7 @@ RSpec.describe VacationRequestsController do
               create(:vacation_request, user: user, status: 'accepted')
             end
 
-            it_should_behave_like 'pretty request'
+            it_should_behave_like 'pretty cancel request'
           end
         end
 
@@ -267,7 +280,7 @@ RSpec.describe VacationRequestsController do
                 .from(2).to(0)
             end
 
-            it_should_behave_like 'pretty request'
+            it_should_behave_like 'pretty cancel request'
           end
 
           context 'when vacation request status is set to "accepted"' do
@@ -275,7 +288,7 @@ RSpec.describe VacationRequestsController do
               create(:vacation_request, user: user, status: 'accepted')
             end
 
-            it_should_behave_like 'pretty request'
+            it_should_behave_like 'pretty cancel request'
           end
         end
 
@@ -316,6 +329,159 @@ RSpec.describe VacationRequestsController do
 
           it_should_behave_like 'unauthorized request'
         end
+      end
+
+      context 'when vacation request status is set to "declined"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'declined')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "cancelled"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'cancelled')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "inprogress"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'inprogress')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+
+      context 'when vacation request status is set to "used"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'used')
+        end
+
+        it_should_behave_like 'request with conflict'
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthenticated request'
+
+      it 'should not change vacation request status' do
+        id = vacation_request.id
+        expect { send_request }
+          .not_to change { VacationRequest.find_by(id: id).status }
+      end
+    end
+  end
+
+  ################################################################### GET #start
+  describe 'GET #start' do
+    let(:team) do
+      create :team, :with_users, number_of_managers: 2, number_of_members: 1
+    end
+    let(:send_request) { get :start, params }
+    let(:params) { Hash[format: :json, id: vacation_request.id] }
+
+    context 'from authenticated user' do
+      before { sign_in user }
+
+      context 'with ID of not existing vacation request' do
+        let(:params) { Hash[format: :json, id: (vacation_request.id - 1)] }
+
+        it 'should respond with status code :not_found (404)' do
+          send_request
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context 'with manager role' do
+        context 'who owns the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: user)
+          end
+
+          context 'when vacation request status is set to "accepted"' do
+            let(:vacation_request) do
+              create(:vacation_request, user: user, status: 'accepted')
+            end
+
+            it_should_behave_like 'pretty start request'
+          end
+        end
+
+        context 'who does not own the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: member)
+          end
+
+          it 'should not change vacation request status' do
+            id = vacation_request.id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+
+          it_should_behave_like 'unauthorized request'
+        end
+      end
+
+      context 'with member role' do
+        let(:user) { member }
+        context 'who owns the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: user)
+          end
+
+          context 'when vacation request status is set to "accepted"' do
+            let(:vacation_request) do
+              create(:vacation_request, user: user, status: 'accepted')
+            end
+
+            it_should_behave_like 'pretty start request'
+          end
+        end
+
+        context 'who does not own the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: manager)
+          end
+
+          it 'should not change vacation request status' do
+            id = vacation_request.id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+
+          it_should_behave_like 'unauthorized request'
+        end
+      end
+
+      context 'with guest role' do
+        let(:user) { guest }
+        context 'who owns the vacation request' do
+          let(:vacation_request) do
+            create(:vacation_request, :with_approval_requests, user: user)
+          end
+
+          it 'should not change vacation request status' do
+            id = vacation_request.id
+
+            expect { send_request }
+              .not_to change { VacationRequest.find_by(id: id).status }
+          end
+
+          it_should_behave_like 'unauthorized request'
+        end
+      end
+
+      context 'when vacation request status is set to "requested"' do
+        let(:vacation_request) do
+          create(:vacation_request, user: user, status: 'requested')
+        end
+
+        it_should_behave_like 'request with conflict'
       end
 
       context 'when vacation request status is set to "declined"' do

--- a/spec/policies/vacation_request_policy_spec.rb
+++ b/spec/policies/vacation_request_policy_spec.rb
@@ -29,7 +29,7 @@ describe VacationRequestPolicy do
     end
   end
 
-  permissions :cancel? do
+  permissions :cancel?, :start? do
     context 'for user with manager role' do
       let(:user) { manager }
 


### PR DESCRIPTION
Vacations with status set to 'accepted' can be set to 'inprogress'
by vacation owner. This functionality is needed to indicate that
vacation is being in use.

Refactor templates for operations
All the buttons that are rendered in the column 'Operations',
in vacations table, are placed in a set of simple templates that
represent particular button each.

Add start action to RoR router
Add the action method as member of vacation_request resource.

Add authorization policy

Add template for 'Start' button
The button represents process of setting 'inprogress' status.

Add handler for 'Start' action

Cover all the changes with tests

Add some refactoring
@alazarchuk , @epmlys , @afurm , @rubycop 