### PR TITLE
Implement setting vacation to used status

### DIFF
--- a/app/assets/javascripts/templates/vacation_operations/used.jst.hamljs
+++ b/app/assets/javascripts/templates/vacation_operations/used.jst.hamljs
@@ -1,0 +1,1 @@
+%button.btn.btn-info{name:'finish'} Finish

--- a/app/policies/vacation_request_policy.rb
+++ b/app/policies/vacation_request_policy.rb
@@ -15,6 +15,10 @@ class VacationRequestPolicy < ApplicationPolicy
     manager_or_member_who_owns_vacation?
   end
 
+  def finish?
+    manager_or_member_who_owns_vacation?
+  end
+
   def start?
     manager_or_member_who_owns_vacation?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
             defaults: { format: :json } do
     member do
       get 'cancel'
+      get 'finish'
       get 'start'
     end
   end

--- a/spec/policies/vacation_request_policy_spec.rb
+++ b/spec/policies/vacation_request_policy_spec.rb
@@ -29,7 +29,7 @@ describe VacationRequestPolicy do
     end
   end
 
-  permissions :cancel?, :start? do
+  permissions :cancel?, :finish?, :start? do
     context 'for user with manager role' do
       let(:user) { manager }
 


### PR DESCRIPTION
Vacations with status set to `inprogress` can be set to `used`
by vacation owner. This functionality is needed to indicate that
vacation is used.

Add finish action to RoR router
Add the action method as member of vacation_request resource.

Add RoR finish action
Add the action method as member of vacation_request resource.

Add authorization policy

Add BB template for `Finish` button
The button represents process of setting `used` status.

Add BB handler for `Finish` action

Cover RoR related changes with tests