### PR TITLE
Implement calculation of available vacations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,4 +12,7 @@ Style/FileName:
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Style/GuardClause:
+  Enabled: false
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #   Vacation Management System for CyberCraft Inc.
 
-##  Install
+##  Installation
 The project is powered by **Ruby**, **Node.js**, **Ruby on Rails**, **Backbone**, and **MySQL**.
 
 
@@ -87,3 +87,6 @@ For details on how to install **Node.js** see https://nodejs.org.
     bundle exec rake db:migrate
     bundle exec rake db:seed
     ```
+
+##  Deployment
+The application server is to be hosted on Heroku.

--- a/app/assets/javascripts/views/vacation_request_form.js
+++ b/app/assets/javascripts/views/vacation_request_form.js
@@ -102,7 +102,7 @@ App.Views.VacationRequestForm = Backbone.View.extend({
 
     this.availableVacations.each(function(model) {
       $badge = this.$('.badge.'+model.attributes.kind);
-      $badge.text(this.model.calculateDuration(this.holidays)+'|'+model.attributes.available_days);
+      $badge.text(this.model.calculateDuration(this.holidays)+'|'+Math.floor(model.attributes.available_days));
     }, this);
   },
 

--- a/app/assets/javascripts/views/vacation_requests_list.js
+++ b/app/assets/javascripts/views/vacation_requests_list.js
@@ -89,10 +89,13 @@ App.Views.VacationRequestsList = Backbone.View.extend({
 
     $.get('vacation_requests/'+row.id.toString()+'/finish')
       .done(function() {
+        // TODO: trigger new vacation request from to refresh available days in badges
         // TODO: implement notification, if needed
         // Trigger table update
         console.log('DONE');
         that.collection.fetch();
+        // TODO: propagate App.Collections.AvailableVacations from the form
+        // via Router
       })
       .fail(function(response) {
         // TODO: implement notification
@@ -124,7 +127,7 @@ App.Views.VacationRequestsList = Backbone.View.extend({
         canBeSetToInprogress = false,
         canBeSetToUsed = false;
 
-    canBeSetToCancelled   = (row.status === App.Vacation.statuses.requested && row.status === App.Vacation.statuses.accepted);
+    canBeSetToCancelled   = (row.status === App.Vacation.statuses.requested || row.status === App.Vacation.statuses.accepted);
     canBeSetToInprogress  = (row.status === App.Vacation.statuses.accepted);
     canBeSetToUsed        = (row.status === App.Vacation.statuses.inprogress);
 

--- a/app/controllers/available_vacations_controller.rb
+++ b/app/controllers/available_vacations_controller.rb
@@ -1,7 +1,13 @@
+require 'available_vacations/calculus'
+
+include AvailableVacations
+
 class AvailableVacationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    render json: current_user.available_vacations
+    @records = current_user.available_vacations
+    @records.each(&:accumulate_more_days)
+    render json: @records
   end
 end

--- a/app/models/available_vacation.rb
+++ b/app/models/available_vacation.rb
@@ -1,3 +1,7 @@
+require 'available_vacations/calculus'
+
+include AvailableVacations
+
 class AvailableVacation < ActiveRecord::Base
   belongs_to :user
 
@@ -17,4 +21,19 @@ class AvailableVacation < ActiveRecord::Base
     :unpaid,
     :sickness
   ]
+
+  def accumulate_more_days
+    diff_in_days = days_since_last_update
+    to_be_upadted = (diff_in_days > 0 && kind != 'unpaid')
+    if to_be_upadted
+      days = diff_in_days * AvailableVacations::RATES[kind.to_sym]
+      update_attribute(:available_days, available_days + days)
+    end
+  end
+
+private
+
+  def days_since_last_update
+    Time.zone.today - updated_at.to_date
+  end
 end

--- a/app/models/holiday.rb
+++ b/app/models/holiday.rb
@@ -11,4 +11,12 @@ class Holiday < ActiveRecord::Base
                             less_than: 5 }
   validates :start,
             inclusion: { in: Date.new(2015, 01, 01)..Date.new(2115, 01, 01) }
+
+  def self.dates
+    all.map(&:dates).flatten
+  end
+
+  def dates
+    (start..(start + duration - 1)).to_a
+  end
 end

--- a/db/migrate/20151019113134_add_employment_date_to_user.rb
+++ b/db/migrate/20151019113134_add_employment_date_to_user.rb
@@ -1,0 +1,5 @@
+class AddEmploymentDateToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :employment_date, :date
+  end
+end

--- a/lib/available_vacations/calculus.rb
+++ b/lib/available_vacations/calculus.rb
@@ -1,0 +1,19 @@
+module AvailableVacations
+  DAYS_IN_YEAR = 365
+  # Number of available days per year for each type of vacation
+  PLANNED_PER_YEAR = 20
+  SICKNESS_PER_YEAR = 21
+  UNPAID_PER_YEAR = 0
+
+  # Number of available days per day for each type of vacation
+  PLANNED_PER_DAY = PLANNED_PER_YEAR.fdiv(DAYS_IN_YEAR)
+  SICKNESS_PER_DAY = SICKNESS_PER_YEAR.fdiv(DAYS_IN_YEAR)
+  UNPAID_PER_DAY = 0
+
+  # Hash of rates
+  RATES = Hash[
+    planned:  PLANNED_PER_DAY,
+    unpaid:   UNPAID_PER_DAY,
+    sickness: SICKNESS_PER_DAY,
+  ]
+end

--- a/spec/factories/available_vacations.rb
+++ b/spec/factories/available_vacations.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :available_vacation do
     available_days  5
-    kind            'unpaid'
+    kind            'planned'
     user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,10 @@
 FactoryGirl.define do
   factory :user do
-    email   { "#{first_name.downcase}.#{last_name.downcase}@i.ua" }
-    first_name  { FFaker::Name.first_name }
-    last_name   { FFaker::Name.last_name }
-    password    'myPrecious'
+    email { "#{first_name.downcase}.#{last_name.downcase}@i.ua" }
+    first_name      { FFaker::Name.first_name }
+    last_name       { FFaker::Name.last_name }
+    employment_date { Date.new(2015, 01, 01) }
+    password        'myPrecious'
 
     trait :with_vacations_of_all_statuses do
       start_date = Time.zone.today

--- a/spec/factories/vacation_requests.rb
+++ b/spec/factories/vacation_requests.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
   factory :vacation_request do
-    kind    'planned'
+    kind              'planned'
     start_date        { Time.zone.now }
     planned_end_date  { (Date.parse(start_date.to_s) + 2.days).to_s }
     actual_end_date   { planned_end_date }
-    status  'requested'
+    status            'requested'
     user
 
     trait :unpaid do

--- a/spec/models/available_vacation_spec.rb
+++ b/spec/models/available_vacation_spec.rb
@@ -23,6 +23,33 @@ RSpec.describe AvailableVacation do
     expect(available_vacation).not_to be_valid
   end
 
+  describe '.accumulate_more_days' do
+    let(:available_vacation) { create(:available_vacation) }
+
+    context 'when the record is up-to-date' do
+      it 'does not update the record' do
+        av_id = available_vacation.id
+        expect { available_vacation.accumulate_more_days }
+          .not_to change { AvailableVacation.find_by!(av_id).available_days }
+      end
+    end
+
+    context 'when the record is not up-to-date' do
+      before do
+        available_vacation.updated_at = Time.zone.now - 1.day
+      end
+
+      it 'updates the record' do
+        av_id = available_vacation.id
+        days = available_vacation.available_days
+        expected = days + AvailableVacations::RATES[:planned]
+        expect { available_vacation.accumulate_more_days }
+          .to change { AvailableVacation.find_by!(av_id).available_days }
+          .to(expected.round(5))
+      end
+    end
+  end
+
   context 'as a brand new object' do
     let(:available_vacation) { AvailableVacation.new }
 


### PR DESCRIPTION
Add `employment_date` column to `users` table

Update RoR User model
The `User#days_since_employment` instance method provides number of days
since the date of employment.
The `User#accumulated_days_of_all_types` instance method provides number
of accumulated available vacations of all types.
The `User#accumulated_days(kind)` instance method provides number
of accumulated available vacations of particular type.
The `User#used_days(kind)` instance method provides number of all used
vacations since employment date.

Update RoR User model factory
Initialize the date of employment.

Update RoR VacationRequest model
The `VacationRequest#used` scope filters used vacations.

Update RoR AvailableVacation model
The `AvailableVacation#accumulate_more_days` instance method updates
`available_days` property by adding more available days if the record
is not up-to-date.

Update RoR AvailableVacationsController
The `index` action method updates number of available days for all
the records before sending them to the client.

Add module for calculations
The `AvailableVacations` module provides configuration data needed for
vacations related calculations.

Update RoR Holiday model with helpers
The `Holiday.dates` class method provides array of all the holidays dates.
The `Holiday#dates` instance method provides array of holiday dates.
The `Holiday.dates` class method actually aggregates results of
the instance method invocations on the list of all holidays records.

Add filter into VacationRequestsController
The `VacationRequestsController#update_available_vacations` method
is hooked with `after_action`.
The method initiates recalculation of available vacations for the same
type as the finished vacation.
The new functionality is covered with tests.

Update RoR VacationRequest model
The `VacationRequest#duration` method provides of the vacation taking
into consideration holidays and weekends. That is, if there are any
weekneds or holidays that vacation date range overlaps with,
they will be properly subtracted.
The `VacationRequest#duration` method is covered with tests.

Update BB App.Views.VacationRequestForm
The form shows in badges only integer part of number of available days.

Fix BB App.Views.VacationRequestsList
The decision logic for showing the `Cancel` button now works properly.

Update rubocop configuration
Disable rule for the guard style checking

Add deployment related section to `README.md`