### PR TITLE
Fix precision in test expectations

### DIFF
--- a/spec/controllers/vacation_requests_controller_spec.rb
+++ b/spec/controllers/vacation_requests_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe VacationRequestsController do
     it 'should properly update available vacations of the user' do
       av_id = user.available_vacations.planned.first.id
       expect { send_request }
-        .to change { AvailableVacation.find_by(id: av_id).available_days }
+        .to change { AvailableVacation.find_by(id: av_id).available_days.to_i }
         .by(-vacation.duration(Holiday.dates))
     end
   end


### PR DESCRIPTION
Test imrovement for `VacationRequestsController#finish` action method.
The number of days to be subtracted must be an integer value.
The number of accumulated days is based on a real number.
To compare two numbers with different base is bad idea.
So, number of accumulated days is coerced to integer value to avoid
test fails, as follows:
  ```
  expected result to have changed by -3.0,
  but was changed by -3.0000000000000018
```