### PR TITLE
Add rake task for importing users

### DIFF
--- a/lib/services/import_user.rb
+++ b/lib/services/import_user.rb
@@ -32,12 +32,12 @@
 # any changes in DB.
 class ImportUser
   EXPECTED_COLUMNS = {
-    'first_name' => "Ім'я",
-    'last_name'  => 'Прізвище',
+    'first_name' => 'First Name',
+    'last_name'  => 'Last Name',
     'email'      => 'Email',
-    'birth_date' => 'ДН',
+    'birth_date' => 'Birth Day',
     'password'   => 'password',
-    'employment_date' => 'Дата приходу на роботу'
+    'employment_date' => 'Employment Date'
   }
 
   STATUSES = {

--- a/lib/services/import_user.rb
+++ b/lib/services/import_user.rb
@@ -1,0 +1,36 @@
+class ImportUser
+  EXPECTED_COLUMNS = %w(first_name last_name email birth_date employment_date password)
+  STATUS_NEW  = 'NEW'
+  STATUS_OK   = 'OK'
+  STATUS_FAIL = 'FAIL'
+
+  attr_reader :error
+
+  def initialize(attributes, options = {})
+    @options = { verbose: false }.merge(options)
+    @attributes = attributes.select { |key| EXPECTED_COLUMNS.include?(key) }
+    @status = 'new'
+    @error = ''
+  end
+
+  def insert_to_db
+    User.create!(@attributes)
+    @status = STATUS_OK
+  rescue StandardError => e
+    @status = STATUS_FAIL
+    @error = e.message
+  end
+
+  def report
+    report_verbose      if      @options[:verbose]
+    report_with_symbol  unless  @options[:verbose]
+  end
+
+  def report_verbose
+    puts "#{@attributes['email']} #{@status} #{@error}".strip
+  end
+
+  def report_with_symbol
+    print @status
+  end
+end

--- a/lib/tasks/users/import_from_csv.rake
+++ b/lib/tasks/users/import_from_csv.rake
@@ -1,0 +1,15 @@
+namespace :users do
+  desc 'Append users from users.csv file into DB'
+  task import_from_csv: :environment do
+    require 'csv'
+    # require 'lib/services/import_user'
+    require File.join(Rails.root, 'lib', 'services', 'import_user')
+
+    records = CSV.parse(File.read('users.csv'), headers: true)
+    records.each do |record|
+      service = ImportUser.new(record.to_hash, verbose: true)
+      service.insert_to_db
+      service.report
+    end
+  end
+end

--- a/lib/tasks/users/import_from_csv.rake
+++ b/lib/tasks/users/import_from_csv.rake
@@ -1,8 +1,7 @@
 namespace :users do
-  desc 'Append users from users.csv file into DB'
+  desc 'Import users from users.csv file into DB'
   task import_from_csv: :environment do
     require 'csv'
-    # require 'lib/services/import_user'
     require File.join(Rails.root, 'lib', 'services', 'import_user')
 
     records = CSV.parse(File.read('users.csv'), headers: true)

--- a/lib/tasks/users/list_as_json.rake
+++ b/lib/tasks/users/list_as_json.rake
@@ -1,0 +1,13 @@
+namespace :users do
+  desc 'List all the users from DB in JSON format, with fields required for user creation, except the password one'
+  task list_as_json: :environment do
+    COLS = %i(id first_name last_name email birth_date employment_date)
+
+    User
+      .select(COLS)
+      .all
+      .each do |user|
+        puts user.attributes.to_json
+      end
+  end
+end


### PR DESCRIPTION
The `users:import_from_csv` task parses a `user.csv` file that expects
the following columns in any order:
  - first_name
  - last_name
  - birth_date
  - email
  - employment_date
  - password

Any additional columns are parsed, but ignored.
Fixes #66

The `users:list_as_json` task just prints each user record with
the following attributes:
  - id
  - first_name
  - last_name
  - birth_date
  - email
  - employment_date