### PR TITLE
Update allowed date range for vacation request

### DIFF
--- a/app/assets/javascripts/helpers/assign_date_picker.js
+++ b/app/assets/javascripts/helpers/assign_date_picker.js
@@ -1,10 +1,13 @@
 // Assign Bootstrap DatePicker to Jquery object
+// https://bootstrap-datepicker.readthedocs.org
 App.Helpers.assignDatePicker = function(container, options) {
   var settings = {
         autoclose: false,
         calendarWeeks: false,
-        format: "yyyy-mm-dd",
-        orientation: "top auto",
+        format: 'yyyy-mm-dd',
+        orientation: 'top auto',
+        startDate: '2013-09-01',
+        endDate: '2050-01-01',
         todayBtn: true,
         todayHighlight: true,
         weekStart: 1,

--- a/app/models/vacation_request.rb
+++ b/app/models/vacation_request.rb
@@ -6,7 +6,7 @@ class VacationRequest < ActiveRecord::Base
             :status, :start_date, :user,
             presence: true
   validates :end_date, :start_date,
-            inclusion: { in: Date.new(2015, 01, 01)..Date.new(2115, 01, 01) }
+            inclusion: { in: Date.new(2013, 9, 1)..Date.new(2050, 1, 1) }
   validate :cannot_intersect_with_other_vacations,
            unless: 'start_date.nil? || end_date.nil?'
 

--- a/spec/models/vacation_request_spec.rb
+++ b/spec/models/vacation_request_spec.rb
@@ -517,19 +517,19 @@ RSpec.describe VacationRequest do
 
     it 'should ensure inclusion of end_date in proper range' do
       vacation_request = build(:vacation_request)
-      vacation_request.end_date = '2014-12-31'
+      vacation_request.end_date = '2013-08-31'
       expect(vacation_request).to be_invalid
 
-      vacation_request.end_date = '2115-12-31'
+      vacation_request.end_date = '2050-01-02'
       expect(vacation_request).to be_invalid
 
-      vacation_request.end_date = '2055-12-31'
+      vacation_request.end_date = '2050-01-01'
       expect(vacation_request).to be_valid
     end
 
     it do
       should validate_inclusion_of(:end_date)
-        .in_range(Date.new(2015, 01, 01)..Date.new(2115, 01, 01))
+        .in_range(Date.new(2013, 9, 1)..Date.new(2050, 1, 1))
     end
   end
 


### PR DESCRIPTION
The minimum possible value is 2013-09-01, and the maximum is 2050-01-01.

Fixes #97