### PR TITLE
Add information about own vacation duration

### DIFF
--- a/app/assets/javascripts/views/personal_vacation_requests.js
+++ b/app/assets/javascripts/views/personal_vacation_requests.js
@@ -29,6 +29,7 @@ App.Views.PersonalVacationRequests = Backbone.View.extend({
 
     this.requests.fetch();
     this.onCancel = _.bind(this.onCancel, this);
+    this.durationFormatter = _.bind(this.durationFormatter, this);
   },
 
   render: function() {
@@ -65,6 +66,13 @@ App.Views.PersonalVacationRequests = Backbone.View.extend({
           valign: 'middle',
           sortable: true
       }, {
+          field: 'end_date',
+          title: 'Duration',
+          align: 'center',
+          valign: 'middle',
+          formatter: this.durationFormatter,
+          sortable: true
+      }, {
           field: 'kind',
           title: 'Type',
           align: 'center',
@@ -80,6 +88,19 @@ App.Views.PersonalVacationRequests = Backbone.View.extend({
           sortable: false
       }],
     });
+  },
+
+  durationFormatter: function(value, row, index) {
+    var duration,
+        vacation = new App.Models.VacationRequest();
+
+    vacation.set('kind', row.kind);
+    vacation.set('start_date', row.start_date);
+    vacation.set('end_date', row.end_date);
+
+    duration = vacation.calculateDuration(this.options.holidays);
+
+    return duration;
   },
 
   ownerOperationsFormatter: function(value, row, index) {

--- a/app/assets/javascripts/views/personal_vacation_requests.js
+++ b/app/assets/javascripts/views/personal_vacation_requests.js
@@ -66,7 +66,6 @@ App.Views.PersonalVacationRequests = Backbone.View.extend({
           valign: 'middle',
           sortable: true
       }, {
-          field: 'end_date',
           title: 'Duration',
           align: 'center',
           valign: 'middle',


### PR DESCRIPTION
The main idea is to utilize existing `App.Models.VacationRequest` model
to calculate a vacation duration taking into consideration holidays and weekends.

The result of calculation is displayed in section with personal vacation requests.

Fixes #110