### PR TITLE
Add duration of each vacation on Vacations page

### DIFF
--- a/app/assets/javascripts/views/vacation_requests.js
+++ b/app/assets/javascripts/views/vacation_requests.js
@@ -21,6 +21,7 @@ App.Views.VacationRequests = Backbone.View.extend({
     }).render();
 
     this.vacationRequestsList = new App.Views.VacationRequestsList({
+      'holidays': this.options.holidays,
       'vacationRequests': this.options.vacationRequests,
       'availableVacations': this.options.availableVacations,
     }).render();

--- a/app/assets/javascripts/views/vacation_requests_list.js
+++ b/app/assets/javascripts/views/vacation_requests_list.js
@@ -11,6 +11,7 @@ App.Views.VacationRequestsList = Backbone.View.extend({
   },
 
   initialize: function(options) {
+    this.options = options;
     this.collection = options.vacationRequests;
     this.availableVacations = options.availableVacations;
 
@@ -19,6 +20,7 @@ App.Views.VacationRequestsList = Backbone.View.extend({
     this.onCancel = _.bind(this.onCancel, this);
     this.onFinish = _.bind(this.onFinish, this);
     this.onStart  = _.bind(this.onStart, this);
+    this.durationFormatter = _.bind(this.durationFormatter, this);
   },
 
   render: function() {
@@ -45,6 +47,12 @@ App.Views.VacationRequestsList = Backbone.View.extend({
           field: 'end_date',
           title: 'End date',
           valign: 'middle',
+          sortable: true
+      }, {
+          title: 'Duration',
+          align: 'center',
+          valign: 'middle',
+          formatter: this.durationFormatter,
           sortable: true
       }, {
           field: 'kind',
@@ -119,6 +127,19 @@ App.Views.VacationRequestsList = Backbone.View.extend({
         console.error('FAIL');
         console.error(response.responseText);
       });
+  },
+
+  durationFormatter: function(value, row, index) {
+      var duration,
+          vacation = new App.Models.VacationRequest();
+
+      vacation.set('kind', row.kind);
+      vacation.set('start_date', row.start_date);
+      vacation.set('end_date', row.end_date);
+
+      duration = vacation.calculateDuration(this.options.holidays);
+
+      return duration;
   },
 
   ownerOperationsFormatter: function(value, row, index) {


### PR DESCRIPTION
The main idea is to utilize existing `App.Models.VacationRequest` model to calculate a vacation duration taking into consideration holidays and weekends.

The result of calculation is displayed in section with the list of personal vacation requests.

Fixes #116