### PR TITLE
Show remaining approvers of vacation request

### DIFF
--- a/app/assets/javascripts/collections/approvers.js
+++ b/app/assets/javascripts/collections/approvers.js
@@ -1,0 +1,3 @@
+App.Collections.Approvers = Backbone.Collection.extend({
+  model: App.Models.Approver,
+});

--- a/app/assets/javascripts/models/approver.js
+++ b/app/assets/javascripts/models/approver.js
@@ -1,0 +1,43 @@
+App.Models.Approver = Backbone.Model.extend({
+  defaults: {
+    'first_name':'',
+    'last_name':''
+  },
+
+  set: function() {
+    var options = {match: true},
+        new_keys = [],
+        expected_keys = _.keys(this.defaults),
+        forbidden_keys = [];
+
+    // Attributes that are not expected by backend in case of a new record,
+    // but it is Ok to initialize a model with these attributes.
+    expected_keys.push('id');
+
+    if (_.isObject(arguments[0])) {
+      options = _.extend(options, arguments[1]);
+      new_keys = _.keys(arguments[0]);
+      forbidden_keys = _.reject(new_keys, function(key) {
+        return _.contains(expected_keys, key);
+      });
+    } else {
+      options = _.extend(options, arguments[2]);
+      new_keys = [arguments[0]];
+      forbidden_keys = _.reject(new_keys, function(key) {
+        return _.contains(expected_keys, key);
+      });
+    }
+
+    if (options.match === true && !_.isEmpty(forbidden_keys)) {
+      message = 'App.Models.Approver.set: option {match: true} allows to set only properties from defaults (';
+      message +=_.keys(this.defaults)+')';
+      message += ', but got (';
+      message += forbidden_keys;
+      message += ')';
+      console.log(message);
+      throw new Error(message);
+    }
+
+    return Backbone.Model.prototype.set.apply(this, arguments);
+  }
+});

--- a/app/assets/javascripts/routers/router.js
+++ b/app/assets/javascripts/routers/router.js
@@ -10,24 +10,29 @@ App.Router = Backbone.Router.extend({
     var holidays = new App.Collections.Holidays(),
         teams = new App.Collections.Teams(),
         approvalRequests = new App.Collections.ApprovalRequests(),
-        availableVacations = new App.Collections.AvailableVacations();
+        availableVacations = new App.Collections.AvailableVacations(),
+        personalVacationRequests = new App.Collections.PersonalVacationRequests();
 
     App.dashboard = new App.Views.Dashboard({
       'holidays': holidays,
       'teams': teams,
       'approvalRequests': approvalRequests,
-      'availableVacations': availableVacations
+      'availableVacations': availableVacations,
+      'personalVacationRequests': personalVacationRequests
     });
 
-    holidays.fetch()
+    personalVacationRequests.fetch()
       .then(function() {
-        teams.fetch()
-          .then(function() {
-            availableVacations.fetch()
-              .then(function() {
-                approvalRequests.fetch();
-              });
-          });
+        return holidays.fetch();
+      })
+      .then(function() {
+        return teams.fetch();
+      })
+      .then(function() {
+        return availableVacations.fetch();
+      })
+      .then(function() {
+        return approvalRequests.fetch();
       });
   },
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   end
 
   def available_vacations
-    # authorize current_user
+    authorize current_user
     records = AvailableVacation.where(user_id: params[:id])
     records.each(&:accumulate_more_days)
 

--- a/app/controllers/vacation_requests_controller.rb
+++ b/app/controllers/vacation_requests_controller.rb
@@ -3,7 +3,7 @@ require 'errors/conflict_error'
 class VacationRequestsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_vacation_request,
-                only: [:show, :update, :cancel, :finish, :start]
+                only: [:show, :update, :approvers, :cancel, :finish, :start]
 
   after_action  :update_available_vacations!,
                 only: [:index, :finish]
@@ -51,6 +51,17 @@ class VacationRequestsController < ApplicationController
     else
       head  status: :not_found
     end
+  end
+
+  def approvers
+    authorize @vacation_request
+
+    users = User
+      .joins(:approval_requests)
+      .where(approval_requests: { vacation_request_id: @vacation_request[:id] })
+      .select(:id, :first_name, :last_name)
+
+    render json: users
   end
 
   def cancel

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -7,6 +7,10 @@ class UserPolicy < ApplicationPolicy
     manager_or_member?
   end
 
+  def available_vacations?
+    manager_or_member?
+  end
+
   def requested_vacations?
     manager_or_member?
   end

--- a/app/policies/vacation_request_policy.rb
+++ b/app/policies/vacation_request_policy.rb
@@ -11,6 +11,10 @@ class VacationRequestPolicy < ApplicationPolicy
     manager_or_member?
   end
 
+  def approvers?
+    member_who_owns_vacation?
+  end
+
   def cancel?
     manager_or_member_who_owns_vacation?
   end
@@ -31,5 +35,9 @@ private
 
   def manager_or_member_who_owns_vacation?
     (user.manager? || user.member?) && user.owns_vacation_request?(record)
+  end
+
+  def member_who_owns_vacation?
+    user.member? && user.owns_vacation_request?(record)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
             only: [:index, :show, :create, :update],
             defaults: { format: :json } do
     member do
+      get 'approvers'
       get 'cancel'
       get 'finish'
       get 'start'

--- a/spec/policies/vacation_request_policy_spec.rb
+++ b/spec/policies/vacation_request_policy_spec.rb
@@ -84,4 +84,60 @@ describe VacationRequestPolicy do
       end
     end
   end
+
+  permissions :approvers? do
+    context 'for user with manager role' do
+      let(:user) { manager }
+
+      context 'who does not own the vacation request' do
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+
+      context 'who owns the vacation request' do
+        let(:vacation_request) { create(:vacation_request, user: user) }
+
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+    end
+
+    context 'for user with member role' do
+      let(:user) { member }
+
+      context 'who does not own the vacation request' do
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+
+      context 'who owns the vacation request' do
+        let(:vacation_request) { create(:vacation_request, user: user) }
+
+        it 'grants access' do
+          expect(subject).to permit(user, vacation_request)
+        end
+      end
+    end
+
+    context 'for user with guest role' do
+      let(:user) { guest }
+
+      context 'who does not own the vacation request' do
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+
+      context 'who owns the vacation request' do
+        let(:vacation_request) { create(:vacation_request, user: user) }
+
+        it 'denies access' do
+          expect(subject).not_to permit(user, vacation_request)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The main idea is to fetch list of remaining users who are in charge for
taking a decision on vacation request.

The following RoR related changes are introduced:
  - vacation_requests/:id/approvers route is added;
  - VacationRequestsController#approvers action method is added;
  - policy for VacationRequestsController#approvers is added.

The following fixes are introduced:
  - Set authorization check for UsersController#available_vacations.

Fixes #101