### PR TITLE
Add RoR CRUD for User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,22 @@ class User < ActiveRecord::Base
 
   validates :employment_date,
             presence: true,
-            inclusion: { in: Date.new(2013, 01, 01)..Date.new(2050, 01, 01) }
+            inclusion: { in: Date.new(2013, 1, 1)..Date.new(2050, 1, 1) }
+
+  attr_accessor :skip_password_validation
+
+  def as_json(options)
+    options[:only] = [
+      :id,
+      :first_name,
+      :last_name,
+      :email,
+      :birth_date,
+      :employment_date
+    ]
+
+    super options
+  end
 
   def accumulated_days(kind)
     days_since_employment * AvailableVacations::RATES[kind.to_sym]
@@ -79,5 +94,12 @@ class User < ActiveRecord::Base
     used_vacations.reduce(0) do |sum, vacation|
       sum + vacation.duration(holidays)
     end
+  end
+
+protected
+
+  def password_required?
+    return false if skip_password_validation
+    super
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,21 +3,27 @@ class UserPolicy < ApplicationPolicy
     user
   end
 
+  def create?
+    user && user.admin?
+  end
+
+  def update?
+    user && user.admin?
+  end
+
+  def destroy?
+    user && user.admin?
+  end
+
   def approval_requests?
-    manager_or_member?
+    user
   end
 
   def available_vacations?
-    manager_or_member?
+    user && user.member?
   end
 
   def requested_vacations?
-    manager_or_member?
-  end
-
-private
-
-  def manager_or_member?
-    (user.manager? || user.member?)
+    user && user.member?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :users,
-            only: [:index],
+            only: [:index, :create, :update, :destroy],
             defaults: { format: :json } do
     member do
       get 'approval_requests'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,10 +2,22 @@ require 'rails_helper'
 
 RSpec.describe UsersController do
   let(:team) { create(:team, :compact) }
+  let(:admin)   { team.team_roles.admins.first.user }
   let(:manager) { team.team_roles.managers.first.user }
   let(:member)  { team.team_roles.members.first.user }
   let(:guest)   { team.team_roles.guests.first.user }
-  let(:user)    { manager }
+  let(:simple_user) { create(:user) }
+
+  shared_examples 'pretty request' do
+    it 'should not throw an exception' do
+      expect { send_request }.not_to raise_error
+    end
+
+    it 'should respond with status code :ok (200)' do
+      send_request
+      expect(response).to have_http_status(:ok)
+    end
+  end
 
   shared_examples 'empty approval_requests request' do
     it 'should not throw an exception' do
@@ -43,7 +55,286 @@ RSpec.describe UsersController do
 
   ################################################################### GET #index
   describe 'GET #index, format: :json' do
-    pending
+    let(:send_request) { get :index, format: :json }
+    let(:create_users) { users }
+    let(:users) { create_list(:user, 5) }
+
+    context 'from authenticated user' do
+      before do
+        create_users
+        sign_in simple_user
+        send_request
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it 'should contain correct records as JSON data in response body' do
+        expected = users
+        expected << simple_user
+        expect(response.body).to match_records_by_ids_with(expected)
+      end
+    end
+
+    context 'from unauthenticated user' do
+      before { send_request }
+
+      it_should_behave_like 'unauthenticated request'
+    end
+  end
+
+  ################################################################# POST #create
+  describe 'POST #create, format: :json' do
+    let(:new_user) { build(:user) }
+    let(:params)        { Hash[format: :json, user: json_data] }
+    let(:json_data)     { YAML.load(new_user.to_json) }
+    let(:send_request)  { post :create, params }
+
+    context 'from authenticated user' do
+      before { sign_in user }
+
+      context 'with role=admin' do
+        let(:user) { admin }
+
+        context 'with correct data' do
+          it 'should add a correct record to DB' do
+            expect { send_request }.to change(User, :count).by(+1)
+            record = User.find_by(email: new_user.email)
+            expect(record).not_to be_nil
+          end
+
+          it 'should respond with properly structured records' do
+            send_request
+            expected = %w(id first_name last_name email birth_date)
+            expected << 'employment_date'
+
+            expect(response.body).to have_json_attributes(expected)
+          end
+
+          it 'should respond with created record as JSON' do
+            send_request
+            expect(response.body).to have_json_attribute(:first_name)
+              .with_value(new_user.first_name)
+            expect(response.body).to have_json_attribute(:last_name)
+              .with_value(new_user.last_name)
+            expect(response.body).to have_json_attribute(:email)
+              .with_value(new_user.email)
+          end
+
+          it_should_behave_like 'pretty request'
+        end
+
+        context 'with incorrect data' do
+          before { new_user.email = '' }
+
+          it 'should respond with status code :unprocessable_entity (422)' do
+            send_request
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it 'should contain error message as JSON data in response body' do
+            send_request
+            expect(response.body).to have_json_attribute(:errors)
+          end
+
+          it 'should not add any record to DB' do
+            expect { send_request }.not_to change(User, :count)
+          end
+        end
+      end
+
+      context 'with role=manager' do
+        let(:user) { manager }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with role=member' do
+        let(:user) { member }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with role=guest' do
+        let(:user) { guest }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with no roles' do
+        let(:user) { simple_user }
+        it_should_behave_like 'unauthorized request'
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthenticated request'
+
+      it 'should not add any record to DB' do
+        expect { send_request }.not_to change(User, :count)
+      end
+    end
+  end
+
+  ################################################################ PATCH #update
+  describe 'PATCH #update, format: :json' do
+    let(:create_user)   { create(:user) }
+    let(:existing_user) { create_user }
+    let(:updated_user)  { build(:user) }
+    let(:params) { Hash[format: :json, id: existing_user.id, user: json_data] }
+    let(:json_data)     { YAML.load(updated_user.to_json) }
+    let(:send_request)  { patch :update, params }
+
+    before { create_user }
+
+    context 'from authenticated user' do
+      before { sign_in user }
+
+      context 'with role=admin' do
+        let(:user) { admin }
+
+        context 'with correct data' do
+          it 'should update specified record in DB' do
+            expect { send_request }.not_to change(User, :count)
+            record = User.find_by(id: existing_user.id)
+            expect(record).not_to be_nil
+            expect(record.email).to eq(updated_user.email)
+          end
+
+          it 'should respond with properly structured records' do
+            send_request
+            expected = %w(id first_name last_name email birth_date)
+            expected << 'employment_date'
+
+            expect(response.body).to have_json_attributes(expected)
+          end
+
+          it 'should respond with updated record as JSON' do
+            send_request
+            expect(response.body).to have_json_attribute(:first_name)
+              .with_value(updated_user.first_name)
+            expect(response.body).to have_json_attribute(:last_name)
+              .with_value(updated_user.last_name)
+            expect(response.body).to have_json_attribute(:email)
+              .with_value(updated_user.email)
+          end
+
+          it_should_behave_like 'pretty request'
+        end
+
+        context 'with incorrect data' do
+          before { updated_user.email = '' }
+
+          it 'should respond with status code :unprocessable_entity (422)' do
+            send_request
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it 'should contain error message as JSON data in response body' do
+            send_request
+            expect(response.body).to have_json_attribute(:errors)
+          end
+
+          it 'should not add any record to DB' do
+            expect { send_request }.not_to change(User, :count)
+          end
+
+          it 'should not update specified record in DB' do
+            expect { send_request }.not_to change(User, :count)
+            record = User.find_by(id: existing_user.id)
+            expect(record).not_to be_nil
+            expect(record.first_name).not_to eq(updated_user.first_name)
+            expect(record.last_name).not_to eq(updated_user.last_name)
+          end
+        end
+      end
+
+      context 'with role=manager' do
+        let(:user) { manager }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with role=member' do
+        let(:user) { member }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with role=guest' do
+        let(:user) { guest }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with no roles' do
+        let(:user) { simple_user }
+        it_should_behave_like 'unauthorized request'
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthenticated request'
+
+      it 'should not add any record to DB' do
+        expect { send_request }.not_to change(User, :count)
+      end
+    end
+  end
+
+  ############################################################## DELETE #destroy
+  describe 'DELETE #destroy' do
+    let(:create_user)   { create(:user) }
+    let(:existing_user) { create_user }
+    let(:params) { Hash[format: :json, id: existing_user.id] }
+    let(:json_data)     { YAML.load(updated_user.to_json) }
+    let(:send_request)  { delete :destroy, params }
+
+    before { create_user }
+
+    context 'from authenticated user' do
+      before { sign_in user }
+
+      context 'with role=admin' do
+        let(:user) { admin }
+
+        it 'should respond with status code :no_content (204)' do
+          send_request
+          expect(response).to have_http_status(:no_content)
+        end
+
+        it 'should delete specified record' do
+          expect { send_request }.to change(User, :count).by(-1)
+          expect(User.find_by(id: existing_user.id)).to be_nil
+        end
+
+        describe 'with attempt to delete a record that does not exist' do
+          before { delete :destroy, id: 0 }
+
+          it { expect(response).to have_http_status(:not_found) }
+        end
+      end
+
+      context 'with role=manager' do
+        let(:user) { manager }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with role=member' do
+        let(:user) { member }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with role=guest' do
+        let(:user) { guest }
+        it_should_behave_like 'unauthorized request'
+      end
+
+      context 'with no roles' do
+        let(:user) { simple_user }
+        it_should_behave_like 'unauthorized request'
+      end
+    end
+
+    context 'from unauthenticated user' do
+      it_should_behave_like 'unauthenticated request'
+
+      it 'should not add any record to DB' do
+        expect { send_request }.not_to change(User, :count)
+      end
+    end
   end
 
   ####################################################### GET #approval_requests
@@ -52,6 +343,7 @@ RSpec.describe UsersController do
     let(:params) { Hash[format: :json, id: user.id] }
 
     context 'from unauthenticated user' do
+      let(:params) { Hash[format: :json, id: 0] }
       before { send_request }
 
       it_should_behave_like 'unauthenticated request'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     email { "#{first_name.downcase}.#{last_name.downcase}@i.ua" }
     first_name      { FFaker::Name.first_name }
     last_name       { FFaker::Name.last_name }
-    employment_date { Date.new(2015, 01, 01) }
+    employment_date { Date.new(2015, 1, 1) }
     password        'myPrecious'
 
     trait :with_vacations_of_all_statuses do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,33 +1,133 @@
 require 'rails_helper'
 
-describe UserPolicy do
+RSpec.describe UserPolicy do
   let(:team) { create(:team, :compact) }
+  let(:simple_user) { create(:user) }
+
+  let(:admin)   { team.team_roles.admins.first.user }
+  let(:manager) { team.team_roles.managers.first.user }
+  let(:member)  { team.team_roles.members.first.user }
+  let(:guest)   { team.team_roles.guests.first.user }
+
+  shared_examples 'a good boy' do
+    it 'grants access' do
+      expect(subject).to permit(user)
+    end
+  end
+
+  shared_examples 'a good guard' do
+    it 'denies access' do
+      expect(subject).not_to permit(user)
+    end
+  end
 
   subject { UserPolicy }
 
-  permissions :approval_requests?, :requested_vacations? do
-    context 'for the team members' do
-      let(:manager) { team.team_roles.managers.first.user }
-      let(:member)  { team.team_roles.members.first.user }
-      let(:guest)   { team.team_roles.guests.first.user }
+  permissions :index? do
+    context 'for user with role=admin' do
+      let(:user) { admin }
+      it_behaves_like 'a good boy'
+    end
 
-      context 'with role=manager' do
-        it 'grants access' do
-          expect(subject).to permit(manager)
-        end
-      end
+    context 'for user with role=manager' do
+      let(:user) { manager }
+      it_behaves_like 'a good boy'
+    end
 
-      context 'with role=member' do
-        it 'grants access' do
-          expect(subject).to permit(member)
-        end
-      end
+    context 'for user with role=member' do
+      let(:user) { member }
+      it_behaves_like 'a good boy'
+    end
 
-      context 'role=guest' do
-        it 'denies access' do
-          expect(subject).not_to permit(guest)
-        end
-      end
+    context 'for user with role=guest' do
+      let(:user) { guest }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'for user with no roles' do
+      let(:user) { simple_user }
+      it_behaves_like 'a good boy'
+    end
+  end
+
+  permissions :create?, :update?, :destroy? do
+    context 'for user with role=admin' do
+      let(:user) { admin }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'for user with role=manager' do
+      let(:user) { manager }
+      it_behaves_like 'a good guard'
+    end
+
+    context 'for user with role=member' do
+      let(:user) { member }
+      it_behaves_like 'a good guard'
+    end
+
+    context 'for user with role=guest' do
+      let(:user) { guest }
+      it_behaves_like 'a good guard'
+    end
+
+    context 'for user with no roles' do
+      let(:user) { simple_user }
+      it_behaves_like 'a good guard'
+    end
+  end
+
+  permissions :approval_requests? do
+    context 'with role=admin' do
+      let(:user) { admin }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'with role=manager' do
+      let(:user) { manager }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'for user with role=member' do
+      let(:user) { member }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'for user with role=guest' do
+      let(:user) { guest }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'for user with no roles' do
+      let(:user) { simple_user }
+      it_behaves_like 'a good boy'
+    end
+  end
+
+  permissions :requested_vacations? do
+    context 'with role=admin' do
+      let(:user) { admin }
+      it_behaves_like 'a good guard'
+    end
+
+    context 'with role=manager' do
+      let(:user) { manager }
+      it_behaves_like 'a good guard'
+    end
+
+    context 'with role=member' do
+      let(:user) { member }
+      it_behaves_like 'a good boy'
+    end
+
+    context 'role=guest' do
+      let(:user) { guest }
+      it_behaves_like 'a good guard'
+    end
+
+    context 'for user with no roles' do
+      let(:user) { simple_user }
+      it_behaves_like 'a good guard'
     end
   end
 end


### PR DESCRIPTION
Update User policy
The following changes are introduced:
  - any registered user can get the list of all users;
  - any registered user can get the list of approval requests assigned to any particular user;
  - any registered user can get the list of all users;
  - only user with a member role can get the list of available vacations for any other user;
  - only user with a member role can get the list of requested vacations for any other user.

NOTE: The policy is a subject for changes in future!
Probably the best option is to move to current user related access.
For instance, to use URI like
`/users/approval_requests`
instead of
`/users/<user_id>/approval_requests`
Another way is to use **Pundit** scopes to provide smart filtering.

Override `User#as_json` to filter out attributes
The main idea is to provide only particular set of attributes by default.
For instance, BB does not care about `created_at` and `updated_at` attributes.

Provide possibility to skip password validation
The main idea is to allow creating new users without passwords. The **Devise** takes care of many manipulations on **User** model, and it provides possibility to save **User** model into DB omitting
password validation.

Update the following CRUD action methods in **UsersController**:
  - index.

Add the following CRUD action methods into **UsersController**:
  - create,
  - update,
  - destroy.