### PR TITLE
Improve Team model

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,5 +5,5 @@ class Team < ActiveRecord::Base
   validates :name,
             presence: true,
             uniqueness: true,
-            length: { minimum: 5, maximum: 35 }
+            length: { minimum: 3, maximum: 80 }
 end

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe TeamsController do
       end
 
       context 'with incorrect data' do
-        let(:team) { build(:team, name: 'Ants') }
+        let(:team) { build(:team, name: 'Oz') }
 
         it 'should respond with status code :unprocessable_entity (422)' do
           send_request
@@ -136,7 +136,7 @@ RSpec.describe TeamsController do
 
       context 'with a reference to not existing record' do
         let(:params)        { Hash[format: :json, id: 1, team: json_data] }
-        let(:another_team)  { build(:team, name: 'Ants') }
+        let(:another_team)  { build(:team, name: 'Oz') }
 
         it 'should respond with status code :not_found (404)' do
           send_request
@@ -149,7 +149,7 @@ RSpec.describe TeamsController do
       end
 
       context 'with incorrect data' do
-        let(:another_team) { build(:team, name: 'Ants') }
+        let(:another_team) { build(:team, name: 'Oz') }
 
         before { send_request }
 
@@ -219,7 +219,7 @@ RSpec.describe TeamsController do
 
       context 'with a reference to not existing record' do
         let(:params)        { Hash[format: :json, id: 1, team: json_data] }
-        let(:another_team)  { build(:team, name: 'Ants') }
+        let(:another_team)  { build(:team, name: 'Oz') }
 
         it 'should respond with status code :not_found (404)' do
           send_request
@@ -232,7 +232,7 @@ RSpec.describe TeamsController do
       end
 
       context 'with incorrect data' do
-        let(:another_team) { build(:team, name: 'Ants') }
+        let(:another_team) { build(:team, name: 'Oz') }
 
         before { send_request }
 

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -7,49 +7,50 @@ FactoryGirl.define do
       number_of_guests    1
     end
 
-    name  { "#{FFaker::Skill.tech_skill} team" }
+    name  { "#{FFaker::Skill.tech_skill} at #{FFaker::Company.name}" }
+    # name  { "#{FFaker::Skill.tech_skill} team" }
 
     trait :with_users do
       after :create do |team, evaluator|
         evaluator.number_of_admins.times do
-          user = FactoryGirl.create(:user)
-          FactoryGirl.create(:team_role, user: user, team: team, role: 'admin')
+          user = create(:user)
+          create(:team_role, user: user, team: team, role: 'admin')
         end
         evaluator.number_of_managers.times do
-          user = FactoryGirl.create(:user)
-          FactoryGirl.create(:team_role, user: user, team: team, role: 'manager')
+          user = create(:user)
+          create(:team_role, user: user, team: team, role: 'manager')
         end
         evaluator.number_of_members.times do
-          user = FactoryGirl.create(:user)
-          FactoryGirl.create(:team_role, user: user, team: team, role: 'member')
+          user = create(:user)
+          create(:team_role, user: user, team: team, role: 'member')
         end
         evaluator.number_of_guests.times do
-          user = FactoryGirl.create(:user)
-          FactoryGirl.create(:team_role, user: user, team: team, role: 'guest')
+          user = create(:user)
+          create(:team_role, user: user, team: team, role: 'guest')
         end
       end
     end
 
     trait :compact do
       after :create do |team|
-        user = FactoryGirl.create(:user)
-        FactoryGirl.create(:team_role, user: user, team: team, role: 'admin')
+        user = create(:user)
+        create(:team_role, user: user, team: team, role: 'admin')
 
-        user = FactoryGirl.create(:user)
-        FactoryGirl.create(:team_role, user: user, team: team, role: 'manager')
+        user = create(:user)
+        create(:team_role, user: user, team: team, role: 'manager')
 
-        user = FactoryGirl.create(:user)
-        FactoryGirl.create(:team_role, user: user, team: team, role: 'member')
+        user = create(:user)
+        create(:team_role, user: user, team: team, role: 'member')
 
-        user = FactoryGirl.create(:user)
-        FactoryGirl.create(:team_role, user: user, team: team, role: 'guest')
+        user = create(:user)
+        create(:team_role, user: user, team: team, role: 'guest')
       end
     end
 
     trait :with_manager_only do
       after :create do |team|
-        user = FactoryGirl.create(:user)
-        FactoryGirl.create(:team_role, user: user, team: team, role: 'manager')
+        user = create(:user)
+        create(:team_role, user: user, team: team, role: 'manager')
       end
     end
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Team do
     it { should validate_presence_of(:name) }
     it do
       should validate_length_of(:name)
-        .is_at_least(5)
-        .is_at_most(35)
+        .is_at_least(3)
+        .is_at_most(80)
     end
   end
 


### PR DESCRIPTION
The idea is to lower minimum team name length to 3 letters,
and to increase maximum team name length to 80 letters.
Another big change is generating a unique team name in factory.