### PR TITLE
Change Teams page visibility

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,14 +30,14 @@
               - if current_user && current_user.member?
                 %li
                   = link_to "Home", '/#dashboard'
-              %li
-                = link_to "Teams", '/#teams'
               - if current_user && current_user.member?
                 %li
                   = link_to "Vacations", '/#vacation_requests'
               %li
                 = link_to "Holidays", '/#holidays'
               - if current_user && current_user.admin?
+                %li
+                  = link_to "Teams", '/#teams'
                 %li
                   = link_to "Users", '/#users'
             %ul.nav.navbar-nav.navbar-right


### PR DESCRIPTION
The main idea is to show the Teams page only for users with admin role.