### PR TITLE
Update rubycop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 Documentation:
   Enabled: false
 
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 
 Style/AccessModifierIndentation:


### PR DESCRIPTION
There was deprecated entity name in config file.